### PR TITLE
refactor: generalize adaptive panels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 import React, { useMemo, useState, useEffect, useCallback } from "react";
 import { DEFAULT_CONFIG, PRIOR_BY_AGE, DEFAULT_AGE_BAND, type AgeBandKey } from "./config/modelConfig";
 import { useAsdEngine } from "./hooks/useAsdEngine";
-import { CANONICAL_CASES, MIGDAS_CONSISTENCY } from "./data/testData";
+import { CANONICAL_CASES, MIGDAS_CONSISTENCY, ABAS3_SEVERITIES as ABAS_SEVERITIES, VINELAND_SEVERITIES, VINELAND_DOMAINS } from "./data/testData";
 import type { Config, SeverityState, CriterionKey, Condition } from "./types";
 
 import { Header, Footer } from "./components/ui";

--- a/src/panels/AbasPanel.tsx
+++ b/src/panels/AbasPanel.tsx
@@ -5,17 +5,23 @@ import { ChipGroup } from "../components/ui";
 import { getBandColor } from "../components/severity";
 
 export function AbasPanel({
-  domains, abas, setABAS
+  title,
+  domains,
+  options,
+  valueMap,
+  setValueMap,
 }:{
-  domains:{key:string;label:string;severities:string[]}[];
-  abas:SeverityState;
-  setABAS:(fn:(s:SeverityState)=>SeverityState)=>void;
+  title: string;
+  domains: { key: string; label: string }[];
+  options: string[];
+  valueMap: SeverityState;
+  setValueMap: (fn: (s: SeverityState) => SeverityState) => void;
 }) {
   return (
-    <Card title="ABAS-3 — Domain Entries">
+    <Card title={title}>
       <div className="grid">
         {domains.map(d=>{
-          const sel = abas[d.key]?.severity || "";
+          const sel = valueMap[d.key]?.severity || "";
           return (
             <section key={d.key} className="card">
               <div className="stack stack--sm">
@@ -24,9 +30,9 @@ export function AbasPanel({
                   {sel && <span className="chip" style={{ background:getBandColor(sel, "goodHigh"), color:"#0b1220" }}>{sel}</span>}
                 </div>
                 <ChipGroup
-                  options={d.severities}
+                  options={options}
                   value={sel}
-                  onChange={(sev)=>setABAS(s=>({ ...s, [d.key]: { ...s[d.key], severity: sev }}))}
+                  onChange={(sev)=>setValueMap(s=>({ ...s, [d.key]: { ...s[d.key], severity: sev }}))}
                   getColor={(label)=>getBandColor(label, "goodHigh")}
                 />
               </div>

--- a/src/panels/VinelandPanel.tsx
+++ b/src/panels/VinelandPanel.tsx
@@ -1,21 +1,26 @@
 import React from "react";
-import type { SeverityState } from "../types";
 import { Card } from "../components/primitives";
 import { ChipGroup } from "../components/ui";
 import { getBandColor } from "../components/severity";
 
 export function VinelandPanel({
-  domains, Vineland, setVineland
+  title,
+  domains,
+  options,
+  valueMap,
+  setValueMap,
 }:{
-  domains:{key:string;label:string;severities:string[]}[];
-  Vineland:SeverityState;
-  setVineland:(fn:(s:SeverityState)=>SeverityState)=>void;
+  title: string;
+  domains: { key: string; label: string }[];
+  options: string[];
+  valueMap: Record<string, string>;
+  setValueMap: (fn: (s: Record<string, string>) => Record<string, string>) => void;
 }) {
   return (
-    <Card title="Vineland — Domain Entries">
+    <Card title={title}>
       <div className="grid">
         {domains.map(d=>{
-          const sel = Vineland[d.key]?.severity || "";
+          const sel = valueMap[d.key] || "";
           return (
             <section key={d.key} className="card">
               <div className="stack stack--sm">
@@ -24,9 +29,9 @@ export function VinelandPanel({
                   {sel && <span className="chip" style={{ background:getBandColor(sel, "goodHigh"), color:"#0b1220" }}>{sel}</span>}
                 </div>
                 <ChipGroup
-                  options={d.severities}
+                  options={options}
                   value={sel}
-                  onChange={(sev)=>setVineland(s=>({ ...s, [d.key]: { ...s[d.key], severity: sev }}))}
+                  onChange={(sev)=>setValueMap(s=>({ ...s, [d.key]: sev }))}
                   getColor={(label)=>getBandColor(label, "goodHigh")}
                 />
               </div>


### PR DESCRIPTION
## Summary
- allow ABAS and Vineland panels to receive generic title, domains and severity options
- consolidate state handling to valueMap/setValueMap
- import ABAS and Vineland option constants into the app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c5aed144883258fdacc1724079398