### PR TITLE
feat: brighten theme and improve score feedback

### DIFF
--- a/src/components/chipGroup.tsx
+++ b/src/components/chipGroup.tsx
@@ -28,16 +28,14 @@ export function ChipGroup({
       {options.map((opt) => {
         const selected = value === opt;
         const bg = selected ? (getColor?.(opt) ?? getBandColor(opt, polarity)) : undefined;
-
-        // Use CSS variable to bypass any !important in your stylesheet
-        const style = bg ? ({ ["--chip-active-bg" as any]: bg } as React.CSSProperties) : undefined;
+        const style = selected && bg ? ({ background: bg, borderColor: bg, color: "#111" } as React.CSSProperties) : undefined;
 
         return (
           <button
             key={String(opt)}
             type="button"
             disabled={disabled}
-            className={"chip" + (selected ? " chip-active" : "")}
+            className={"chip" + (selected ? " chip--active" : "")}
             style={style}
             onClick={() => onChange(String(opt))}
             aria-pressed={selected}

--- a/src/index.css
+++ b/src/index.css
@@ -3,14 +3,19 @@
   --radius-xs:6px; --radius-sm:10px; --radius-md:14px;
   --gap-1:6px; --gap-2:10px; --gap-3:14px; --gap-4:18px;
 
-  --bg:hsl(220 18% 7%);
-  --panel:hsl(220 18% 10%);
-  --elev:hsl(220 18% 12%);
-  --border:hsl(220 14% 18%);
-  --muted:hsl(220 10% 60%);
-  --text:hsl(220 15% 92%);
+  --bg:hsl(210 20% 98%);
+  --panel:hsl(0 0% 100%);
+  --elev:hsl(210 20% 96%);
+  --border:hsl(214 20% 90%);
+  --muted:hsl(215 16% 45%);
+  --text:hsl(215 28% 17%);
   --accent:hsl(217 92% 60%);
   --accent-2:hsl(217 92% 66%);
+  --tone-danger:#fecaca;
+  --tone-warn:#fde68a;
+  --tone-neutral:#e5e7eb;
+  --tone-good:#bbf7d0;
+  --tone-best:#86efac;
 
   --shadow-1:0 1px 2px hsl(220 40% 2%/.6);
   --shadow-2:0 6px 18px hsl(220 40% 2%/.35);
@@ -32,10 +37,12 @@
 /* ===== Base ===== */
 *{box-sizing:border-box}
 html,body,#root{height:100%}
+html{scroll-behavior:smooth}
 body{
   margin:0;background:var(--bg);color:var(--text);
   -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;
   font:14px/1.45 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+  transition:background-color var(--t-med) var(--ease),color var(--t-med) var(--ease);
 }
 a,button{transition:color var(--t-fast) var(--ease),background-color var(--t-fast) var(--ease),border-color var(--t-fast) var(--ease),box-shadow var(--t-fast) var(--ease),transform var(--t-fast) var(--ease)}
 /* neutral button baseline */
@@ -61,7 +68,8 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .topbar .title{font-size:16px;margin:0 0 2px 0}
 .topbar .subtitle{color:var(--muted);font-size:12px}
 
-.card{background:var(--panel);border:1px solid var(--border);border-radius:14px;box-shadow:var(--shadow-1);padding:16px}
+.card{background:var(--panel);border:1px solid var(--border);border-radius:14px;box-shadow:var(--shadow-1);padding:16px;transition:box-shadow var(--t-fast) var(--ease)}
+.card:hover{box-shadow:var(--shadow-2)}
 .card__bar{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
 .section-title{font-size:14px;font-weight:700;color:var(--muted);margin:0}
 
@@ -71,14 +79,16 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .btn--accent:hover{filter:brightness(1.05)}
 
 .tabbar{display:flex;gap:8px;flex-wrap:wrap}
-.tab{border:1px solid var(--border);background:var(--panel);border-radius:999px;padding:6px 12px;font-weight:500;color:var(--muted)}
-.tab--active{color:var(--text);background:hsl(217 92% 60%/.14);border-color:hsl(217 92% 60%/.3)}
+.tab{border:1px solid var(--border);background:var(--panel);border-radius:999px;padding:6px 12px;font-weight:500;color:var(--muted);transition:background-color var(--t-fast) var(--ease),color var(--t-fast) var(--ease)}
+.tab--active{color:var(--text);background:color-mix(in hsl, var(--accent) 14%, transparent);border-color:color-mix(in hsl, var(--accent) 30%, transparent)}
 
-.chip{border:1px solid var(--border);background:hsl(220 18% 12%);border-radius:999px;padding:6px 10px;color:var(--text);opacity:.9}
-.chip--active{opacity:1;border-color:hsl(217 92% 60%/.5)} /* do NOT add inset overlay */
+.chip{border:1px solid var(--border);background:var(--elev);border-radius:999px;padding:6px 10px;color:var(--text);opacity:.9;transition:background-color var(--t-fast) var(--ease)}
+.chip--active{opacity:1}
 
-.badge{display:inline-block;padding:6px 10px;border-radius:999px;font-weight:600;background:hsl(6 70% 40%/.16);border:1px solid hsl(6 70% 40%/.3)}
-.badge--ok{background:hsl(140 70% 35%/.18);border-color:hsl(140 70% 35%/.36)}
+.badge{display:inline-block;padding:6px 10px;border-radius:999px;font-weight:600}
+.badge--ok{background:var(--tone-good);border:1px solid color-mix(in hsl, var(--tone-good) 60%, black 40%)}
+.badge--warn{background:var(--tone-warn);border:1px solid color-mix(in hsl, var(--tone-warn) 60%, black 40%)}
+.badge--danger{background:var(--tone-danger);border:1px solid color-mix(in hsl, var(--tone-danger) 60%, black 40%)}
 
 /* ===== Print (summary) ===== */
 @media print{

--- a/src/panels/SummaryPanel.tsx
+++ b/src/panels/SummaryPanel.tsx
@@ -14,8 +14,8 @@ export function SummaryPanel({
           </div>
           <div>
             Decision: {model.p >= model.cut
-              ? <span className="badge ok">Above threshold — proceed</span>
-              : <span className="badge warn">Below threshold — consider more data</span>}
+              ? <span className="badge badge--ok">Above threshold — proceed</span>
+              : <span className="badge badge--warn">Below threshold — consider more data</span>}
           </div>
           <div className="card" style={{textAlign:"center"}}>{supportEstimate}</div>
           <div className="row row--between" style={{gap:8}}>


### PR DESCRIPTION
## Summary
- switch site to a light color palette and add tone variables for red/yellow/green score feedback
- smooth out UI with hover transitions and animated chips/tabs
- fix chip group and summary badges so impairment reads red and high functioning green

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c5d0afb5c83258947c2d3ab432462