### PR TITLE
test: add canonical test data validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test --experimental-transform-types"
   },
   "engines": {
     "node": ">=20.19 <21 || >=22.12"

--- a/src/data/testData.test.ts
+++ b/src/data/testData.test.ts
@@ -1,0 +1,7 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateTestData } from './testData.ts';
+
+test('returns no validation errors for canonical cases', () => {
+  assert.deepStrictEqual(validateTestData(), []);
+});


### PR DESCRIPTION
## Summary
- add `node:test` suite verifying canonical case data
- wire up npm test script for Node's test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5b3aaa9883259fe12ce058f0999a