### PR TITLE
Refactor assessment sections and enhance UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,17 @@ export default function App() {
 
   // ---------- core state ----------
   const [config, setConfig] = useState<Config>(DEFAULT_CONFIG);
-  const TABS = ["ASD Measures", "Adaptive", "History", "Comorbidity", "Advanced", "Report"];
+  const TABS = [
+    "ASD Measures",
+    "Adaptive",
+    "Intellectual",
+    "Executive Function",
+    "Sensory",
+    "Language",
+    "History",
+    "Comorbidity",
+    "Report",
+  ];
   const [activeTab, setActiveTab] = useState(0);
   const [devOpen, setDevOpen] = useState(false);
 
@@ -217,6 +227,11 @@ export default function App() {
         <section className="stack">
           {activeTab === 0 && (
             <>
+              <AssessmentPanel
+                assessments={assessments}
+                setAssessments={setAssessments}
+                domains={["Autism questionnaires", "Autism observations", "Autism interviews"]}
+              />
               <SrsPanel title="SRS-2 Parent" domains={config.srs2Domains} srs2={srs2} setSRS2={setSRS2} />
               {isSchoolAge && (
                 <SrsPanel title="SRS-2 Teacher" domains={config.srs2Domains} srs2={srs2Teacher} setSRS2={setSRS2Teacher} />
@@ -224,9 +239,14 @@ export default function App() {
               {/* TODO: MIGDAS panel (presentational) */}
             </>
           )}
-          
+
           {activeTab === 1 && (
             <>
+              <AssessmentPanel
+                assessments={assessments}
+                setAssessments={setAssessments}
+                domains={["Adaptive questionnaires"]}
+              />
               <AbasPanel
                 title="ABAS-3 Parent"
                 domains={config.abasDomains}
@@ -257,24 +277,50 @@ export default function App() {
           )}
 
           {activeTab === 2 && (
+            <AssessmentPanel
+              assessments={assessments}
+              setAssessments={setAssessments}
+              domains={["Intellectual assessment"]}
+            />
+          )}
+
+          {activeTab === 3 && (
+            <AssessmentPanel
+              assessments={assessments}
+              setAssessments={setAssessments}
+              domains={["Executive function questionnaires"]}
+            />
+          )}
+
+          {activeTab === 4 && (
+            <AssessmentPanel
+              assessments={assessments}
+              setAssessments={setAssessments}
+              domains={["Sensory Assessment"]}
+            />
+          )}
+
+          {activeTab === 5 && (
+            <AssessmentPanel
+              assessments={assessments}
+              setAssessments={setAssessments}
+              domains={["Language assessment"]}
+            />
+          )}
+
+          {activeTab === 6 && (
             <Card title="History / Observation">
               {/* TODO: move history + observation into a HistoryPanel */}
             </Card>
           )}
 
-          {activeTab === 3 && (
+          {activeTab === 7 && (
             <Card title="Comorbidity / Differential">
               {/* TODO: move diff flags into a DiffPanel */}
             </Card>
           )}
 
-          {activeTab === 4 && (
-            <>
-              <AssessmentPanel assessments={assessments} setAssessments={setAssessments} />
-            </>
-          )}
-
-          {activeTab === 5 && (
+          {activeTab === 8 && (
             <ReportPanel
               model={model}
               supportEstimate={supportEstimate}

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -136,6 +136,10 @@ export function Footer({ version, ruleHash }:{version:string; ruleHash:string}) 
       <div style={{ marginTop: 6 }}>
         Decision support only; clinician judgement prevails • Build {version} • Rule set {ruleHash}
       </div>
+      <div style={{ marginTop: 6 }}>
+        <a href="https://www.autismcrc.com.au" target="_blank" rel="noopener noreferrer">Autism CRC</a> •
+        <a href="https://www.autismguidelines.org.au" target="_blank" rel="noopener noreferrer">Autism Guidelines</a>
+      </div>
     </footer>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -61,6 +61,7 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .stack--md{gap:12px}
 .stack--lg{gap:16px}
 .grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+.grid--sm{grid-template-columns:repeat(auto-fit,minmax(180px,1fr))}
 .small{font-size:12px;color:var(--muted)}
 
 /* ===== UI ===== */

--- a/src/panels/AbasPanel.tsx
+++ b/src/panels/AbasPanel.tsx
@@ -19,7 +19,7 @@ export function AbasPanel({
 }) {
   return (
     <Card title={title}>
-      <div className="grid">
+      <div className="grid grid--sm">
         {domains.map(d=>{
           const sel = valueMap[d.key]?.severity || "";
           return (

--- a/src/panels/AssessmentPanel.tsx
+++ b/src/panels/AssessmentPanel.tsx
@@ -2,13 +2,17 @@ import React from "react";
 import { Card, Row, Stack } from "../components/primitives";
 import type { AssessmentSelection } from "../types";
 
-export function AssessmentPanel({ assessments, setAssessments }:{
+export function AssessmentPanel({ assessments, setAssessments, domains }:{
   assessments: AssessmentSelection[];
   setAssessments: (fn:(arr:AssessmentSelection[])=>AssessmentSelection[])=>void;
+  domains?: string[];
 }){
   const togglePrimary = (i:number) => {
     setAssessments(arr => {
       const next = arr.map((a,idx)=> idx===i ? { ...a, primary: !a.primary } : a);
+      if (!arr[i].primary && next[i].primary && next[i].selected){
+        window.alert(`You have selected ${next[i].selected} as the main assessment for ${next[i].domain.toLowerCase()}`);
+      }
       return [...next].sort((a,b)=>Number(b.primary)-Number(a.primary));
     });
   };
@@ -22,21 +26,24 @@ export function AssessmentPanel({ assessments, setAssessments }:{
   return (
     <Card title="Assessment Tools">
       <Stack gap="sm">
-        {assessments.map((a,i)=>(
-          <Row key={a.domain} justify="between" align="center">
-            <label style={{flex:1}}>
-              <div className="section-title">{a.domain}</div>
-              <select value={a.selected || ""} onChange={e=>changeSelection(i,e.target.value)}>
-                <option value="">Select</option>
-                {a.options.map(o => <option key={o} value={o}>{o}</option>)}
-              </select>
-            </label>
-            <label className="row row--center" style={{gap:4}}>
-              <input type="checkbox" checked={a.primary || false} onChange={()=>togglePrimary(i)} />
-              Main
-            </label>
-          </Row>
-        ))}
+        {assessments.map((a,i)=>{
+          if (domains && !domains.includes(a.domain)) return null;
+          return (
+            <Row key={a.domain} justify="between" align="center">
+              <label style={{flex:1}}>
+                <div className="section-title">{a.domain}</div>
+                <select value={a.selected || ""} onChange={e=>changeSelection(i,e.target.value)}>
+                  <option value="">Select</option>
+                  {a.options.map(o => <option key={o} value={o}>{o}</option>)}
+                </select>
+              </label>
+              <label className="row row--center" style={{gap:4}}>
+                <input type="checkbox" checked={a.primary || false} onChange={()=>togglePrimary(i)} />
+                Main
+              </label>
+            </Row>
+          );
+        })}
       </Stack>
     </Card>
   );

--- a/src/panels/SrsPanel.tsx
+++ b/src/panels/SrsPanel.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import type { SeverityState } from "../types";
 import { Card } from "../components/primitives";
-import { ChipGroup } from "../components/ui";
-import { getBandColor } from "../components/severity";
 
 export function SrsPanel({
   title,
@@ -17,25 +15,20 @@ export function SrsPanel({
 }) {
   return (
     <Card title={title}>
-      <div className="grid">
+      <div className="grid grid--sm">
         {domains.map(d=>(
           <section key={d.key} className="card">
             <div className="stack stack--sm">
-              <div className="section-title">{d.label}</div>
-              <ChipGroup
-                options={d.severities}
-                value={srs2[d.key]?.severity || ""}
-                onChange={(sev)=>setSRS2(s=>({ ...s, [d.key]: { ...s[d.key], severity: sev }}))}
-                getColor={(label)=>{
-                  switch(label){
-                    case "Average": return getBandColor("Average","goodHigh");
-                    case "Mild": return getBandColor("Low Average","goodHigh");
-                    case "Moderate": return getBandColor("Moderately Elevated","goodHigh");
-                    case "Severe": return getBandColor("Severe","goodHigh");
-                    default: return getBandColor(label,"goodHigh");
-                  }
-                }}
-              />
+              <label>
+                <div className="section-title">{d.label}</div>
+                <select
+                  value={srs2[d.key]?.severity || ""}
+                  onChange={(e)=>setSRS2(s=>({ ...s, [d.key]: { ...s[d.key], severity: e.target.value }}))}
+                >
+                  <option value="">Select</option>
+                  {d.severities.map(sev => <option key={sev} value={sev}>{sev}</option>)}
+                </select>
+              </label>
             </div>
           </section>
         ))}

--- a/src/panels/VinelandPanel.tsx
+++ b/src/panels/VinelandPanel.tsx
@@ -18,7 +18,7 @@ export function VinelandPanel({
 }) {
   return (
     <Card title={title}>
-      <div className="grid">
+      <div className="grid grid--sm">
         {domains.map(d=>{
           const sel = valueMap[d.key] || "";
           return (


### PR DESCRIPTION
## Summary
- Reorganize assessment selectors into dedicated tabs and add new sections for intellectual, executive function, sensory, and language
- Replace SRS-2 chips with dropdown ratings and smaller grid layout
- Add alert when marking an assessment as main and include autism resource links in footer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c69cc7ca88325a4a6577d9c055a1f