### PR TITLE
feat: handle additional assessments in UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { SummaryPanel } from "./panels/SummaryPanel";
 import { VinelandPanel } from "./panels/VinelandPanel";
 import { ReportPanel } from "./panels/ReportPanel";
 import { AssessmentPanel } from "./panels/AssessmentPanel";
+import { GenericInstrumentPanel } from "./panels/GenericInstrumentPanel";
 import { AiChat } from "./components/AiChat";
 
 const initSeverityState = (domains: { key: string }[]): SeverityState =>
@@ -110,6 +111,27 @@ export default function App() {
     { domain: "Sensory Assessment", options: ["Sensory profile 2"], selected: "Sensory profile 2", primary: true },
   ]);
 
+  const NAME_MAP: Record<string, string> = {
+    ABAS3: "ABAS-3",
+    Vineland: "Vineland-3",
+    MIGDAS: "MIGDAS-2",
+    ADOS: "ADOS-2",
+    BRIEF2: "BRIEF-2",
+    WISC: "WISC/WAIS/WPPSI",
+    WPPSI: "WISC/WAIS/WPPSI",
+    WAIS: "WISC/WAIS/WPPSI",
+    "Sensory profile 2": "Sensory Profile 2",
+    CELF5: "CELF-5",
+  };
+
+  const getSelectedNames = useCallback(
+    (domain: string) =>
+      assessments
+        .filter((a) => a.domain === domain && a.selected)
+        .map((a) => NAME_MAP[a.selected!] || a.selected!) ,
+    [assessments],
+  );
+
   const getInstrumentBand = useCallback(
     (name: string) => instruments.find((x) => x.name === name)?.band || "",
     [instruments],
@@ -122,6 +144,14 @@ export default function App() {
   const hasSrs = assessments.some((a) => a.selected === "SRS-2");
   const hasAbas = assessments.some((a) => a.selected === "ABAS3");
   const hasVineland = assessments.some((a) => a.selected?.startsWith("Vineland"));
+
+  const selectedAutismQs = getSelectedNames("Autism questionnaires");
+  const selectedAutismObs = getSelectedNames("Autism observations");
+  const selectedAutismInterviews = getSelectedNames("Autism interviews");
+  const selectedIntellectual = Array.from(new Set(getSelectedNames("Intellectual assessment")));
+  const selectedExecutive = getSelectedNames("Executive function questionnaires");
+  const selectedSensory = getSelectedNames("Sensory Assessment");
+  const selectedLanguage = getSelectedNames("Language assessment");
 
   // ---------- prior via age band ----------
   const [age, setAge] = useState(10);
@@ -341,6 +371,30 @@ export default function App() {
                       )}
                     </>
                   )}
+                  {selectedAutismQs.filter((n) => n !== "SRS-2").length > 0 && (
+                    <GenericInstrumentPanel
+                      selected={selectedAutismQs.filter((n) => n !== "SRS-2")}
+                      instruments={instruments}
+                      setInstruments={setInstruments}
+                      configs={config.defaultInstruments}
+                    />
+                  )}
+                  {selectedAutismObs.filter((n) => n !== "MIGDAS-2").length > 0 && (
+                    <GenericInstrumentPanel
+                      selected={selectedAutismObs.filter((n) => n !== "MIGDAS-2")}
+                      instruments={instruments}
+                      setInstruments={setInstruments}
+                      configs={config.defaultInstruments}
+                    />
+                  )}
+                  {selectedAutismInterviews.length > 0 && (
+                    <GenericInstrumentPanel
+                      selected={selectedAutismInterviews}
+                      instruments={instruments}
+                      setInstruments={setInstruments}
+                      configs={config.defaultInstruments}
+                    />
+                  )}
                   {/* TODO: MIGDAS panel (presentational) */}
                 </>
               )}
@@ -388,19 +442,51 @@ export default function App() {
               )}
 
               {activeTab === 2 && (
-                <AssessmentPanel domain="Intellectual assessment" assessments={assessments} setAssessments={setAssessments} />
+                <>
+                  <AssessmentPanel domain="Intellectual assessment" assessments={assessments} setAssessments={setAssessments} />
+                  <GenericInstrumentPanel
+                    selected={selectedIntellectual}
+                    instruments={instruments}
+                    setInstruments={setInstruments}
+                    configs={config.defaultInstruments}
+                  />
+                </>
               )}
 
               {activeTab === 3 && (
-                <AssessmentPanel domain="Executive function questionnaires" assessments={assessments} setAssessments={setAssessments} />
+                <>
+                  <AssessmentPanel domain="Executive function questionnaires" assessments={assessments} setAssessments={setAssessments} />
+                  <GenericInstrumentPanel
+                    selected={selectedExecutive}
+                    instruments={instruments}
+                    setInstruments={setInstruments}
+                    configs={config.defaultInstruments}
+                  />
+                </>
               )}
 
               {activeTab === 4 && (
-                <AssessmentPanel domain="Sensory Assessment" assessments={assessments} setAssessments={setAssessments} />
+                <>
+                  <AssessmentPanel domain="Sensory Assessment" assessments={assessments} setAssessments={setAssessments} />
+                  <GenericInstrumentPanel
+                    selected={selectedSensory}
+                    instruments={instruments}
+                    setInstruments={setInstruments}
+                    configs={config.defaultInstruments}
+                  />
+                </>
               )}
 
               {activeTab === 5 && (
-                <AssessmentPanel domain="Language assessment" assessments={assessments} setAssessments={setAssessments} />
+                <>
+                  <AssessmentPanel domain="Language assessment" assessments={assessments} setAssessments={setAssessments} />
+                  <GenericInstrumentPanel
+                    selected={selectedLanguage}
+                    instruments={instruments}
+                    setInstruments={setInstruments}
+                    configs={config.defaultInstruments}
+                  />
+                </>
               )}
 
               {activeTab === 6 && <Card title="History / Observation">{/* TODO: HistoryPanel */}</Card>}

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -62,10 +62,13 @@ export const DEFAULT_CONFIG: Config = {
     { name: "ADI-R", scoreField: "band", thresholds: [] },
     { name: "ASRS",  scoreField: "score", thresholds: [] },
     { name: "GARS", scoreField: "standard", thresholds: [] },
+    { name: "CARS", scoreField: "standard", thresholds: [] },
     { name: "SRS-2", scoreField: "t", thresholds: [] },
     { name: "Vineland-3", scoreField: "composite", thresholds: [] }, // <-- MUST exist
     { name: "ABAS-3", scoreField: "composite", thresholds: [] },
     { name: "WISC/WAIS/WPPSI", scoreField: "index", thresholds: [] },
+    { name: "BRIEF-2", scoreField: "t", thresholds: [] },
+    { name: "BDEFS", scoreField: "t", thresholds: [] },
     { name: "Sensory Profile 2", scoreField: "standard", thresholds: [] },
     { name: "CELF-5", scoreField: "index", thresholds: [] },
     { name: "AQ", scoreField: "raw", thresholds: [] },

--- a/src/hooks/useAsdEngine.ts
+++ b/src/hooks/useAsdEngine.ts
@@ -57,7 +57,7 @@ export function useAsdEngine(
       srsEntered ||
       migEntered ||
       withValues.some((i) =>
-        ["SRS-2", "ADOS-2", "MIGDAS-2", "GARS", "ADI-R", "ASRS"].includes(i.name)
+        ["SRS-2", "ADOS-2", "MIGDAS-2", "GARS", "CARS", "ADI-R", "ASRS", "AQ"].includes(i.name)
       );
 
     const historyOk = history.developmentalConcerns.trim().length > 10 && history.earlyOnset;

--- a/src/panels/GenericInstrumentPanel.tsx
+++ b/src/panels/GenericInstrumentPanel.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Card, Row } from "../components/primitives";
+import type { InstrumentEntry, InstrumentConfig } from "../types";
+
+export function GenericInstrumentPanel({
+  selected,
+  instruments,
+  setInstruments,
+  configs,
+}: {
+  selected: string[];
+  instruments: InstrumentEntry[];
+  setInstruments: (fn: (arr: InstrumentEntry[]) => InstrumentEntry[]) => void;
+  configs: InstrumentConfig[];
+}) {
+  const items = instruments.filter((i) => selected.includes(i.name));
+  if (!items.length) return null;
+
+  const getFieldLabel = (name: string) =>
+    configs.find((c) => c.name === name)?.scoreField || "score";
+
+  const setValue = (name: string, value: number | undefined) => {
+    setInstruments((arr) =>
+      arr.map((i) => (i.name === name ? { ...i, value } : i))
+    );
+  };
+
+  const setBand = (name: string, band: string) => {
+    setInstruments((arr) =>
+      arr.map((i) => (i.name === name ? { ...i, band } : i))
+    );
+  };
+
+  return (
+    <>
+      {items.map((i) => (
+        <Card key={i.name} title={i.name}>
+          <Row justify="between" align="center">
+            <label style={{ flex: 1 }}>
+              {getFieldLabel(i.name)}:
+              <input
+                type="number"
+                value={i.value ?? ""}
+                onChange={(e) =>
+                  setValue(
+                    i.name,
+                    e.target.value === "" ? undefined : Number(e.target.value)
+                  )
+                }
+              />
+            </label>
+            <label style={{ flex: 1 }}>
+              Band:
+              <input
+                type="text"
+                value={i.band ?? ""}
+                onChange={(e) => setBand(i.name, e.target.value)}
+              />
+            </label>
+          </Row>
+        </Card>
+      ))}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add generic instrument panel to capture scores for selected assessments
- expand default instrument list and name mapping for new tools
- treat CARS and AQ as ASD instruments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c73e1b8308325983a42ea30ee818a