### PR TITLE
Improve assessment workflow UI and feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import type { Config, SeverityState, Condition, AssessmentSelection } from "./ty
 
 import { Header, Footer } from "./components/ui";
 import { Container, Tabs, Card } from "./components/primitives";
+import { MinDatasetProgress } from "./components/MinDatasetProgress";
 import { SrsPanel } from "./panels/SrsPanel";
 import { AsrsPanel } from "./panels/AsrsPanel";
 import { AbasPanel } from "./panels/AbasPanel";
@@ -102,6 +103,13 @@ export default function App() {
   // ---------- instruments ----------
   const [instruments, setInstruments] = useState(
     DEFAULT_CONFIG.defaultInstruments.map((i) => ({ name: i.name, value: undefined as number | undefined, band: "" })),
+  );
+  const metInstrumentCount = useMemo(
+    () =>
+      instruments.filter(
+        (i) => i.value !== undefined || (i.band && i.band.trim() !== "")
+      ).length,
+    [instruments],
   );
 
   // ---------- assessment selections ----------
@@ -345,6 +353,8 @@ export default function App() {
             </Card>
           )}
 
+          <MinDatasetProgress count={metInstrumentCount} total={config.minDataset.minInstruments} />
+
           <Tabs tabs={TABS as unknown as string[]} active={activeTab} onSelect={setActiveTab} />
 
           <div className="layout">
@@ -524,22 +534,22 @@ export default function App() {
 
             {/* RIGHT: summary */}
             <section className="stack stack--md">
-              <SummaryPanel
-                model={model}
-                config={config}
-                supportEstimate={supportEstimate}
-                recommendation={recommendation}
-                exportSummary={exportSummary}
-              />
-              <AiChat />
-            </section>
-          </div>
-        </>
-      ) : (
-        <Card title={`${condition} assessments`}>Assessments for {condition} will be added soon.</Card>
-      )}
+                <SummaryPanel
+                  model={model}
+                  config={config}
+                  supportEstimate={supportEstimate}
+                  recommendation={recommendation}
+                  exportSummary={exportSummary}
+                />
+              </section>
+            </div>
+          </>
+        ) : (
+          <Card title={`${condition} assessments`}>Assessments for {condition} will be added soon.</Card>
+        )}
 
-      <Footer version="v0.6" ruleHash={ruleHash} />
-    </Container>
-  );
-}
+        <Footer version="v0.6" ruleHash={ruleHash} />
+        <AiChat />
+      </Container>
+    );
+  }

--- a/src/components/AiChat.tsx
+++ b/src/components/AiChat.tsx
@@ -3,6 +3,7 @@ import { Card, Row } from "./primitives";
 import { ASSESSMENT_INFO } from "../data/assessmentInfo";
 
 export function AiChat() {
+  const [open, setOpen] = useState(false);
   const [messages, setMessages] = useState<{ from: "user" | "bot"; text: string }[]>([
     { from: "bot", text: "Hello! I can help with ASD case formulation." },
   ]);
@@ -18,9 +19,7 @@ export function AiChat() {
     setInput("");
 
     setTimeout(() => {
-      const key = Object.keys(ASSESSMENT_INFO).find((k) =>
-        norm(text).includes(k)
-      );
+      const key = Object.keys(ASSESSMENT_INFO).find((k) => norm(text).includes(k));
       const reply = key
         ? `${ASSESSMENT_INFO[key].name}: ${ASSESSMENT_INFO[key].domains.join(", ")}. ${ASSESSMENT_INFO[key].notes}`
         : `Consider how "${text}" relates to social communication and restricted behaviours.`;
@@ -30,25 +29,39 @@ export function AiChat() {
   };
 
   return (
-    <Card title="AI Assistant">
-      <div className="chat-log">
-        {messages.map((m, i) => (
-          <div key={i} className={`chat-msg chat-msg--${m.from}`}>
-            {m.text}
-          </div>
-        ))}
-      </div>
-      <Row>
-        <input
-          style={{ flex: 1 }}
-          value={input}
-          placeholder="Ask about the case..."
-          onChange={(e) => setInput(e.target.value)}
-        />
-        <button type="button" className="btn btn--accent" onClick={send}>
-          Send
-        </button>
-      </Row>
-    </Card>
+    <>
+      <button
+        type="button"
+        className="chat-bubble"
+        onClick={() => setOpen((o) => !o)}
+        title="AI Assistant"
+      >
+        💬
+      </button>
+      {open && (
+        <div className="chat-window">
+          <Card title="AI Assistant" right={<button onClick={() => setOpen(false)}>×</button>}>
+            <div className="chat-log">
+              {messages.map((m, i) => (
+                <div key={i} className={`chat-msg chat-msg--${m.from}`}>
+                  {m.text}
+                </div>
+              ))}
+            </div>
+            <Row>
+              <input
+                style={{ flex: 1 }}
+                value={input}
+                placeholder="Ask about the case..."
+                onChange={(e) => setInput(e.target.value)}
+              />
+              <button type="button" className="btn btn--accent" onClick={send}>
+                Send
+              </button>
+            </Row>
+          </Card>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/components/MinDatasetProgress.tsx
+++ b/src/components/MinDatasetProgress.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export function MinDatasetProgress({ count, total }: { count: number; total: number }) {
+  const pct = total ? Math.min(100, (count / total) * 100) : 0;
+  return (
+    <div className="stack stack--sm">
+      <div className="row row--between">
+        <div>Minimum dataset: {count}/{total} met</div>
+      </div>
+      <div className="progress-bar">
+        <div className="progress-bar__fill" style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -59,12 +59,24 @@ export const DEFAULT_CONFIG: Config = {
   defaultInstruments: [
     { name: "ADOS-2", scoreField: "standard", thresholds: [] },
     { name: "MIGDAS-2", scoreField: "standard", thresholds: [] },
-    { name: "ADI-R", scoreField: "band", thresholds: [] },
+    {
+      name: "ADI-R",
+      scoreField: "band",
+      thresholds: [],
+      bandLabel: "Social Interaction Band (ADI-R)",
+      bandOptions: ["1", "2", "3", "4"],
+    },
     { name: "ASRS",  scoreField: "score", thresholds: [] },
     { name: "GARS", scoreField: "standard", thresholds: [] },
     { name: "CARS", scoreField: "standard", thresholds: [] },
     { name: "SRS-2", scoreField: "t", thresholds: [] },
-    { name: "Vineland-3", scoreField: "composite", thresholds: [] }, // <-- MUST exist
+    {
+      name: "Vineland-3",
+      scoreField: "composite",
+      thresholds: [],
+      bandLabel: "Composite Band (Vineland-3)",
+      bandOptions: [...VINELAND_SEVERITIES],
+    }, // <-- MUST exist
     { name: "ABAS-3", scoreField: "composite", thresholds: [] },
     { name: "WISC/WAIS/WPPSI", scoreField: "index", thresholds: [] },
     { name: "BRIEF-2", scoreField: "t", thresholds: [] },

--- a/src/index.css
+++ b/src/index.css
@@ -63,7 +63,7 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .row--between{justify-content:space-between}
 .row--center{align-items:center}
 .stack{display:grid}
-.stack--sm{gap:8px}
+.stack--sm{gap:6px}
 .stack--md{gap:12px}
 .stack--lg{gap:16px}
 .grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
@@ -78,7 +78,7 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .card{background:var(--panel);border:1px solid var(--border);border-radius:14px;box-shadow:var(--shadow-1);padding:20px;transition:box-shadow var(--t-fast) var(--ease)}
 .card:hover{box-shadow:var(--shadow-2)}
 .card__bar{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
-.section-title{font-size:14px;font-weight:700;color:var(--muted);margin:0}
+.section-title{font-size:16px;font-weight:700;color:var(--text);margin:0 0 4px 0;text-decoration:underline}
 
 .btn{height:34px;padding:0 12px;border:1px solid var(--border);background:var(--panel);color:var(--text);border-radius:10px;box-shadow:var(--shadow-1)}
 .btn:hover{box-shadow:var(--shadow-2)}
@@ -100,6 +100,13 @@ button:disabled{opacity:.6;cursor:not-allowed}
 /* progress bar */
 .progress-bar{width:100%;height:8px;background:var(--tone-neutral);border-radius:4px;overflow:hidden}
 .progress-bar__fill{height:100%;background:var(--accent-2)}
+
+input,select{padding:4px 6px;font-size:14px;width:100%}
+.invalid{border:1px solid var(--tone-danger)}
+
+/* floating chat */
+.chat-bubble{position:fixed;bottom:16px;right:16px;z-index:100;border-radius:9999px;background:var(--accent);color:#fff;padding:12px;box-shadow:var(--shadow-2)}
+.chat-window{position:fixed;bottom:72px;right:16px;z-index:100;width:300px}
 
 /* AI chat */
 .chat-log{display:flex;flex-direction:column;gap:8px;max-height:200px;overflow-y:auto;margin-bottom:12px}

--- a/src/panels/AssessmentPanel.tsx
+++ b/src/panels/AssessmentPanel.tsx
@@ -56,6 +56,8 @@ export function AssessmentPanel({
             <label style={{ flex: 1 }}>
               <select
                 value={a.selected || ""}
+                className={a.selected ? "" : "invalid"}
+                title={a.selected ? "" : "Select assessment"}
                 onChange={(e) => changeSelection(a.index, e.target.value)}
               >
                 <option value="">Select</option>
@@ -81,9 +83,11 @@ export function AssessmentPanel({
             )}
           </Row>
         ))}
-        <button type="button" className="btn" onClick={addAssessment}>
-          Add Assessment
-        </button>
+        <Row>
+          <button type="button" className="btn" onClick={addAssessment}>
+            Add Assessment
+          </button>
+        </Row>
       </div>
     </Card>
   );

--- a/src/panels/GenericInstrumentPanel.tsx
+++ b/src/panels/GenericInstrumentPanel.tsx
@@ -16,8 +16,8 @@ export function GenericInstrumentPanel({
   const items = instruments.filter((i) => selected.includes(i.name));
   if (!items.length) return null;
 
-  const getFieldLabel = (name: string) =>
-    configs.find((c) => c.name === name)?.scoreField || "score";
+  const getConfig = (name: string) => configs.find((c) => c.name === name);
+  const getFieldLabel = (name: string) => getConfig(name)?.scoreField || "score";
 
   const setValue = (name: string, value: number | undefined) => {
     setInstruments((arr) =>
@@ -41,6 +41,8 @@ export function GenericInstrumentPanel({
               <input
                 type="number"
                 value={i.value ?? ""}
+                className={i.value === undefined ? "invalid" : ""}
+                title={i.value === undefined ? "Required" : ""}
                 onChange={(e) =>
                   setValue(
                     i.name,
@@ -49,14 +51,41 @@ export function GenericInstrumentPanel({
                 }
               />
             </label>
-            <label style={{ flex: 1 }}>
-              Band:
-              <input
-                type="text"
-                value={i.band ?? ""}
-                onChange={(e) => setBand(i.name, e.target.value)}
-              />
-            </label>
+            {(() => {
+              const cfg = getConfig(i.name);
+              if (!cfg) return null;
+              const showBand = cfg.bandLabel || cfg.bandOptions || cfg.scoreField === "band";
+              if (!showBand) return null;
+              const label = cfg.bandLabel || "Band";
+              return (
+                <label style={{ flex: 1 }}>
+                  {label}:
+                  {cfg.bandOptions ? (
+                    <select
+                      value={i.band ?? ""}
+                      className={i.band ? "" : "invalid"}
+                      title={i.band ? "" : "Select option"}
+                      onChange={(e) => setBand(i.name, e.target.value)}
+                    >
+                      <option value="">Select</option>
+                      {cfg.bandOptions.map((o) => (
+                        <option key={o} value={o}>
+                          {o}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type="number"
+                      value={i.band ?? ""}
+                      className={i.band ? "" : "invalid"}
+                      title={i.band ? "" : "Required"}
+                      onChange={(e) => setBand(i.name, e.target.value)}
+                    />
+                  )}
+                </label>
+              );
+            })()}
           </Row>
         </Card>
       ))}

--- a/src/panels/SrsPanel.tsx
+++ b/src/panels/SrsPanel.tsx
@@ -16,20 +16,36 @@ export function SrsPanel({
   return (
     <Card title={title}>
       <div className="grid grid--sm">
-        {domains.map(d=>(
+        {domains.map((d) => (
           <section key={d.key} className="card">
-            <div className="stack stack--sm">
-              <label>
-                <div className="section-title">{d.label}</div>
-                <select
-                  value={srs2[d.key]?.severity || ""}
-                  onChange={(e)=>setSRS2(s=>({ ...s, [d.key]: { ...s[d.key], severity: e.target.value }}))}
-                >
-                  <option value="">Select</option>
-                  {d.severities.map(sev => <option key={sev} value={sev}>{sev}</option>)}
-                </select>
-              </label>
-            </div>
+            <details>
+              <summary className="section-title">
+                {d.label}
+                {srs2[d.key]?.severity ? ` – ${srs2[d.key]?.severity}` : ""}
+              </summary>
+              <div className="stack stack--sm">
+                <label>
+                  <select
+                    value={srs2[d.key]?.severity || ""}
+                    className={srs2[d.key]?.severity ? "" : "invalid"}
+                    title={srs2[d.key]?.severity ? "" : "Select severity"}
+                    onChange={(e) =>
+                      setSRS2((s) => ({
+                        ...s,
+                        [d.key]: { ...s[d.key], severity: e.target.value },
+                      }))
+                    }
+                  >
+                    <option value="">Select</option>
+                    {d.severities.map((sev) => (
+                      <option key={sev} value={sev}>
+                        {sev}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+            </details>
           </section>
         ))}
       </div>

--- a/src/panels/SummaryPanel.tsx
+++ b/src/panels/SummaryPanel.tsx
@@ -1,10 +1,16 @@
-import { Card, Button, Stack } from "../components/primitives";
+import { Card, Stack } from "../components/primitives";
 
 export function SummaryPanel({
   model, config, supportEstimate, recommendation, exportSummary
 }:{ model:any; config:any; supportEstimate:string; recommendation:string[]; exportSummary:()=>void }) {
+  const handleExport = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value;
+    if (v === "summary") exportSummary();
+    if (v === "full") window.print();
+    e.target.value = "";
+  };
   return (
-    <aside className="summary">
+    <aside className="summary" style={{position:"sticky", top:0}}>
       <Card title="Summary">
         <Stack>
           <div>
@@ -18,9 +24,20 @@ export function SummaryPanel({
               : <span className="badge badge--warn">Below threshold — consider more data</span>}
           </div>
           <div className="card" style={{textAlign:"center"}}>{supportEstimate}</div>
-          <div className="row row--between" style={{gap:8}}>
-            <Button onClick={exportSummary}>Export summary</Button>
-            <Button kind="primary" onClick={()=>window.print()}>Export full</Button>
+          <div className="row" style={{gap:8}}>
+            <label style={{flex:1}}>
+              <select defaultValue="" onChange={handleExport} title="Export options">
+                <option value="" disabled>
+                  Export...
+                </option>
+                <option value="summary" title="Export only the summary view">
+                  Summary
+                </option>
+                <option value="full" title="Export the full report">
+                  Full
+                </option>
+              </select>
+            </label>
           </div>
         </Stack>
       </Card>

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,15 @@ export type MinDatasetRules = {
   requireObservation: boolean;
 };
 
-export type InstrumentConfig = { name: string; scoreField: string; thresholds: any[] };
+export type InstrumentConfig = {
+  name: string;
+  scoreField: string;
+  thresholds: any[];
+  /** Optional label for the band field */
+  bandLabel?: string;
+  /** Optional set of allowed band values; renders a dropdown when provided */
+  bandOptions?: string[];
+};
 
 /** Runtime entry for free-form instruments (supports score OR label-only band, e.g., Vineland composite band) */
 export type InstrumentEntry = {


### PR DESCRIPTION
## Summary
- Replace free-text band inputs with dropdown selections and validation
- Add collapsible domain panels and a minimum dataset progress indicator
- Pin summary panel with unified export dropdown and floating AI assistant

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7eadc86c832599ddab22841c4380