### PR TITLE
Improve spacing between progress tracker and tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -270,92 +270,94 @@ export default function App() {
 
       {condition === "ASD" ? (
         <>
-          <Card>
-            <label className="row row--center" style={{ gap: 8 }}>
-              Age
-              <input
-                type="number"
-                value={age}
-                min={0}
-                onChange={(e) => setAge(Number(e.target.value))}
-                style={{ width: 60 }}
-              />
-            </label>
-          </Card>
-
-          <Card>
-            <span className="small">
-              <b>Minimum dataset:</b> {ribbon}
-            </span>
-            <div className="progress-bar">
-              <div className="progress-bar__fill" style={{ width: `${progress * 100}%` }} />
-            </div>
-          </Card>
-
-          {devOpen && (
+          <div className="stack stack--lg">
             <Card>
-              <div className="row">
-                <select id="fixtureSelect">
-                  {CANONICAL_CASES.map((c) => (
-                    <option key={c.id} value={c.id}>
-                      {c.id} — {c.title}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  onClick={() => {
-                    const selEl = document.getElementById("fixtureSelect") as HTMLSelectElement | null;
-                    const sel = selEl ? CANONICAL_CASES.find((c) => c.id === selEl.value) : undefined;
-                    if (!sel) return;
+              <label className="row row--center" style={{ gap: 8 }}>
+                Age
+                <input
+                  type="number"
+                  value={age}
+                  min={0}
+                  onChange={(e) => setAge(Number(e.target.value))}
+                  style={{ width: 60 }}
+                />
+              </label>
+            </Card>
 
-                    setSRS2((prev) => {
-                      const next = { ...prev } as SeverityState;
-                      if (sel.srs2)
-                        Object.entries(sel.srs2).forEach(
-                          ([k, v]) => (next[k] = { ...(next[k] || {}), severity: v as string }),
-                        );
-                      return next;
-                    });
-
-                    setABAS((prev) => {
-                      const next = { ...prev } as SeverityState;
-                      if (sel.abas3)
-                        Object.entries(sel.abas3).forEach(
-                          ([k, v]) => (next[k] = { ...(next[k] || {}), severity: v as string }),
-                        );
-                      return next;
-                    });
-
-                    setWISC((prev) => {
-                      const next = { ...prev } as SeverityState;
-                      if (sel.wisc)
-                        Object.entries(sel.wisc).forEach(
-                          ([k, v]) => (next[k] = { ...(next[k] || {}), severity: v as string }),
-                        );
-                      return next;
-                    });
-
-                    if (sel.migdas) setMIGDAS({ consistency: sel.migdas.consistency, notes: sel.migdas.notes });
-
-                    setHistory((h) => ({
-                      ...h,
-                      developmentalConcerns: "Auto-filled for fixture; replace with clinical history.",
-                      earlyOnset: !!sel.flags?.earlyOnset,
-                      crossContextImpairment: !!sel.flags?.crossContextImpairment,
-                      maskingIndicators: !!sel.flags?.masking,
-                    }));
-                  }}
-                >
-                  Load
-                </button>
-                <div className="small">Dev fixtures for sanity-checks. (Label-only)</div>
+            <Card>
+              <span className="small">
+                <b>Minimum dataset:</b> {ribbon}
+              </span>
+              <div className="progress-bar">
+                <div className="progress-bar__fill" style={{ width: `${progress * 100}%` }} />
               </div>
             </Card>
-          )}
 
-          <MinDatasetProgress count={metInstrumentCount} total={config.minDataset.minInstruments} />
+            {devOpen && (
+              <Card>
+                <div className="row">
+                  <select id="fixtureSelect">
+                    {CANONICAL_CASES.map((c) => (
+                      <option key={c.id} value={c.id}>
+                        {c.id} — {c.title}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    onClick={() => {
+                      const selEl = document.getElementById("fixtureSelect") as HTMLSelectElement | null;
+                      const sel = selEl ? CANONICAL_CASES.find((c) => c.id === selEl.value) : undefined;
+                      if (!sel) return;
 
-          <Tabs tabs={TABS as unknown as string[]} active={activeTab} onSelect={setActiveTab} />
+                      setSRS2((prev) => {
+                        const next = { ...prev } as SeverityState;
+                        if (sel.srs2)
+                          Object.entries(sel.srs2).forEach(
+                            ([k, v]) => (next[k] = { ...(next[k] || {}), severity: v as string }),
+                          );
+                        return next;
+                      });
+
+                      setABAS((prev) => {
+                        const next = { ...prev } as SeverityState;
+                        if (sel.abas3)
+                          Object.entries(sel.abas3).forEach(
+                            ([k, v]) => (next[k] = { ...(next[k] || {}), severity: v as string }),
+                          );
+                        return next;
+                      });
+
+                      setWISC((prev) => {
+                        const next = { ...prev } as SeverityState;
+                        if (sel.wisc)
+                          Object.entries(sel.wisc).forEach(
+                            ([k, v]) => (next[k] = { ...(next[k] || {}), severity: v as string }),
+                          );
+                        return next;
+                      });
+
+                      if (sel.migdas) setMIGDAS({ consistency: sel.migdas.consistency, notes: sel.migdas.notes });
+
+                      setHistory((h) => ({
+                        ...h,
+                        developmentalConcerns: "Auto-filled for fixture; replace with clinical history.",
+                        earlyOnset: !!sel.flags?.earlyOnset,
+                        crossContextImpairment: !!sel.flags?.crossContextImpairment,
+                        maskingIndicators: !!sel.flags?.masking,
+                      }));
+                    }}
+                  >
+                    Load
+                  </button>
+                  <div className="small">Dev fixtures for sanity-checks. (Label-only)</div>
+                </div>
+              </Card>
+            )}
+
+            <MinDatasetProgress count={metInstrumentCount} total={config.minDataset.minInstruments} />
+
+            <Tabs tabs={TABS as unknown as string[]} active={activeTab} onSelect={setActiveTab} />
+          </div>
 
           <div className="layout">
             {/* LEFT: panels per tab */}

--- a/src/index.css
+++ b/src/index.css
@@ -85,7 +85,7 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .btn--accent{background:var(--accent);border-color:transparent;color:#fff}
 .btn--accent:hover{filter:brightness(1.05)}
 
-.tabbar{display:flex;gap:12px;flex-wrap:wrap}
+.tabbar{display:flex;gap:16px;flex-wrap:wrap}
 .tab{border:1px solid var(--border);background:var(--panel);border-radius:999px;padding:6px 12px;font-weight:500;color:var(--muted);transition:background-color var(--t-fast) var(--ease),color var(--t-fast) var(--ease)}
 .tab--active{color:var(--text);background:color-mix(in hsl, var(--accent) 14%, transparent);border-color:color-mix(in hsl, var(--accent) 30%, transparent)}
 


### PR DESCRIPTION
## Summary
- add vertical stack spacing between age field, dataset bar, progress tracker, and tabs
- widen tab bar gap to 1rem for consistent pill spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d02d850b883258c3e9c092a6f757c