### PR TITLE
Add history and comorbidity panels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,8 @@ import { ReportPanel } from "./panels/ReportPanel";
 import { AssessmentPanel } from "./panels/AssessmentPanel";
 import { GenericInstrumentPanel } from "./panels/GenericInstrumentPanel";
 import { DomainPanel } from "./panels/DomainPanel";
+import { HistoryPanel } from "./panels/HistoryPanel";
+import { DiffPanel } from "./panels/DiffPanel";
 import { AiChat } from "./components/AiChat";
 
 const initSeverityState = (domains: { key: string }[]): SeverityState =>
@@ -84,7 +86,12 @@ export default function App() {
   const [history, setHistory] = useState({
     developmentalConcerns: "",
     earlyOnset: false,
+    earlySocial: false,
+    earlyCommunication: false,
+    earlyRRB: false,
+    regression: false,
     crossContextImpairment: false,
+    familyHistory: false,
     maskingIndicators: false,
   });
 
@@ -577,9 +584,16 @@ export default function App() {
                 </>
               )}
 
-              {activeTab === 6 && <Card title="History / Observation">{/* TODO: HistoryPanel */}</Card>}
+              {activeTab === 6 && (
+                <HistoryPanel
+                  history={history}
+                  setHistory={setHistory}
+                  observation={observation}
+                  setObservation={setObservation}
+                />
+              )}
 
-              {activeTab === 7 && <Card title="Comorbidity / Differential">{/* TODO: DiffPanel */}</Card>}
+              {activeTab === 7 && <DiffPanel diff={diff} setDiff={setDiff} />}
 
               {activeTab === 8 && (
                 <ReportPanel

--- a/src/hooks/useAsdEngine.ts
+++ b/src/hooks/useAsdEngine.ts
@@ -16,7 +16,12 @@ export function useAsdEngine(
   history: {
     developmentalConcerns: string;
     earlyOnset: boolean;
+    earlySocial: boolean;
+    earlyCommunication: boolean;
+    earlyRRB: boolean;
+    regression: boolean;
     crossContextImpairment: boolean;
+    familyHistory: boolean;
     maskingIndicators: boolean;
   },
   observation: Record<CriterionKey | "notes", any>,
@@ -114,6 +119,16 @@ export function useAsdEngine(
       altAnxiety: (diff as any).Anxiety || (diff as any).Depression ? 1 : 0,
       altOther: (diff as any).FASD || (diff as any).Tics || !!(diff as any).Other ? 1 : 0,
     };
+
+    // Developmental history indicators
+    ev.A1 += history.earlySocial ? 0.6 : -0.2;
+    ev.A3 += history.earlyCommunication ? 0.6 : -0.2;
+    ev.B2 += history.earlyRRB ? 0.6 : -0.2;
+    if (history.regression) {
+      ev.A1 += 0.3;
+      ev.A3 += 0.3;
+    }
+    if (history.familyHistory) ev.onsetEarly += 0.2;
 
     // Clinician observation (0..3 each)
     (["A1", "A2", "A3", "B1", "B2", "B3", "B4"] as const).forEach((k) => {

--- a/src/panels/DiffPanel.tsx
+++ b/src/panels/DiffPanel.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Card } from "../components/primitives";
+
+export function DiffPanel({
+  diff,
+  setDiff,
+}: {
+  diff: Record<string, any>;
+  setDiff: (fn: (d: any) => any) => void;
+}) {
+  const update = (k: string, v: any) => setDiff((d: any) => ({ ...d, [k]: v }));
+
+  const items: [string, string][] = [
+    ["ADHD", "ADHD indicators"],
+    ["DLD", "Language disorder"],
+    ["ID", "Intellectual disability"],
+    ["Anxiety", "Anxiety/OCD"],
+    ["Depression", "Depression"],
+    ["TraumaPTSD", "Trauma/PTSD"],
+    ["FASD", "FASD"],
+    ["Tics", "Tics"],
+  ];
+
+  return (
+    <Card title="Comorbidity / Differential">
+      <div className="stack stack--sm">
+        {items.map(([key, label]) => (
+          <label key={key}>
+            <input
+              type="checkbox"
+              checked={!!diff[key]}
+              onChange={(e) => update(key, e.target.checked)}
+            />
+            {label}
+          </label>
+        ))}
+        <label>
+          Other
+          <input
+            type="text"
+            value={diff.Other || ""}
+            onChange={(e) => update("Other", e.target.value)}
+          />
+        </label>
+      </div>
+    </Card>
+  );
+}
+
+export default DiffPanel;

--- a/src/panels/HistoryPanel.tsx
+++ b/src/panels/HistoryPanel.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { Card } from "../components/primitives";
+
+export function HistoryPanel({
+  history,
+  setHistory,
+  observation,
+  setObservation,
+}: {
+  history: {
+    developmentalConcerns: string;
+    earlyOnset: boolean;
+    earlySocial: boolean;
+    earlyCommunication: boolean;
+    earlyRRB: boolean;
+    regression: boolean;
+    crossContextImpairment: boolean;
+    familyHistory: boolean;
+    maskingIndicators: boolean;
+  };
+  setHistory: (fn: (h: any) => any) => void;
+  observation: Record<string, any>;
+  setObservation: (fn: (o: any) => any) => void;
+}) {
+  const updateHistory = (k: string, v: any) => setHistory((h: any) => ({ ...h, [k]: v }));
+  const updateObservation = (k: string, v: any) =>
+    setObservation((o: any) => ({ ...o, [k]: v }));
+
+  return (
+    <div className="stack stack--md">
+      <Card title="Developmental History">
+        <div className="stack stack--sm">
+          <label>
+            <div className="section-title">Developmental concerns</div>
+            <textarea
+              value={history.developmentalConcerns}
+              onChange={(e) => updateHistory("developmentalConcerns", e.target.value)}
+            />
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.earlyOnset}
+              onChange={(e) => updateHistory("earlyOnset", e.target.checked)}
+            />
+            Symptom onset before 3 years
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.earlySocial}
+              onChange={(e) => updateHistory("earlySocial", e.target.checked)}
+            />
+            Early social delays
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.earlyCommunication}
+              onChange={(e) => updateHistory("earlyCommunication", e.target.checked)}
+            />
+            Early communication delays
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.earlyRRB}
+              onChange={(e) => updateHistory("earlyRRB", e.target.checked)}
+            />
+            Early restricted or repetitive behaviours
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.regression}
+              onChange={(e) => updateHistory("regression", e.target.checked)}
+            />
+            Regression in language or social skills
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.crossContextImpairment}
+              onChange={(e) => updateHistory("crossContextImpairment", e.target.checked)}
+            />
+            Consistent symptoms across environments
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.familyHistory}
+              onChange={(e) => updateHistory("familyHistory", e.target.checked)}
+            />
+            Family history of ASD or related conditions
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.maskingIndicators}
+              onChange={(e) => updateHistory("maskingIndicators", e.target.checked)}
+            />
+            Masking indicators
+          </label>
+        </div>
+      </Card>
+
+      <Card title="Clinician Observation">
+        <div className="grid grid--sm" style={{ marginBottom: 16 }}>
+          {["A1", "A2", "A3", "B1", "B2", "B3", "B4"].map((k) => (
+            <label key={k} className="stack stack--xs">
+              <div className="section-title">{k}</div>
+              <select
+                value={observation[k]}
+                onChange={(e) => updateObservation(k, Number(e.target.value))}
+              >
+                {[0, 1, 2, 3].map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ))}
+        </div>
+        <label className="stack stack--xs">
+          <div className="section-title">Notes</div>
+          <textarea
+            value={observation.notes}
+            onChange={(e) => updateObservation("notes", e.target.value)}
+          />
+        </label>
+      </Card>
+    </div>
+  );
+}
+
+export default HistoryPanel;


### PR DESCRIPTION
## Summary
- add structured developmental history and observation inputs
- support comorbidity/differential checkboxes
- factor history indicators into evidence calculation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d89e678508325958a0c9860de9564