### PR TITLE
feat: include client profile and detailed report

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import {
   SENSORY_PROFILE_DOMAINS,
   CELF5_DOMAINS,
 } from "./data/testData";
-import type { Config, SeverityState, Condition, AssessmentSelection } from "./types";
+import type { Config, SeverityState, Condition, AssessmentSelection, ClientProfile } from "./types";
 
 import { Header, Footer } from "./components/ui";
 import { Container, Tabs, Card } from "./components/primitives";
@@ -123,6 +123,14 @@ export default function App() {
     date: new Date().toISOString().slice(0, 10),
     attested: false,
   });
+
+  const [client, setClient] = useState<ClientProfile>({ name: "", age: "" });
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("clientProfile");
+      if (stored) setClient(JSON.parse(stored));
+    }
+  }, []);
 
   const [reportVoice, setReportVoice] = useState<"clinical" | "dual">("dual");
 
@@ -610,6 +618,8 @@ export default function App() {
                   assessments={assessments}
                   history={history}
                   config={config}
+                  client={client}
+                  setClient={setClient}
                 />
               )}
             </section>

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,3 +70,8 @@ export type AssessmentSelection = {
   selected?: string;
   primary?: boolean;
 };
+
+export type ClientProfile = {
+  name: string;
+  age: string;
+};


### PR DESCRIPTION
## Summary
- capture client name and age with persistent profile storage
- expand report panel to detail all assessments and show client data
- define ClientProfile type for consistent handling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d8c2fa8ac8325a4c6557aa25251b0