### PR TITLE
style: distinguish add assessment control

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -97,6 +97,17 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .badge--warn{background:var(--tone-warn);border:1px solid color-mix(in hsl, var(--tone-warn) 60%, black 40%)}
 .badge--danger{background:var(--tone-danger);border:1px solid color-mix(in hsl, var(--tone-danger) 60%, black 40%)}
 
+/* assessment picker & cards */
+.assessment-add-row{background:color-mix(in hsl,var(--accent) 14%,transparent);border:1px solid var(--accent);border-radius:10px;padding:8px 12px}
+.assessment-add-row select{background:transparent;border:none;width:100%}
+.assessment-divider{margin:12px 0;border:none;border-top:1px solid var(--border)}
+.assessment-card{background:var(--elev);border:1px solid var(--border);border-radius:10px;box-shadow:var(--shadow-1);padding:12px}
+.assessment-card__header{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
+.assessment-card__body{margin-bottom:8px}
+.assessment-card__footer{text-align:right}
+.assessment-placeholder{padding:16px;border:2px dashed var(--border);border-radius:10px;text-align:center;color:var(--muted)}
+.text-danger{color:color-mix(in hsl,var(--tone-danger) 60%,black 40%)}
+
 /* progress bar */
 .progress-bar{width:100%;height:8px;background:var(--tone-neutral);border-radius:4px;overflow:hidden}
 .progress-bar__fill{height:100%;background:var(--accent-2)}

--- a/src/panels/AssessmentPanel.tsx
+++ b/src/panels/AssessmentPanel.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Card, Row } from "../components/primitives";
+import React, { useState } from "react";
+import { Card } from "../components/primitives";
 import type { AssessmentSelection } from "../types";
 
 export function AssessmentPanel({
@@ -15,12 +15,17 @@ export function AssessmentPanel({
     .map((a, index) => ({ ...a, index }))
     .filter((a) => a.domain === domain);
 
-  const addAssessment = () => {
+  const options = items[0]?.options || [];
+
+  const [pickerValue, setPickerValue] = useState("");
+  const [pickerError, setPickerError] = useState("");
+
+  const addAssessment = (value: string) => {
     const template = items[0];
     if (!template) return;
     setAssessments((arr) => [
       ...arr,
-      { domain, options: template.options, selected: "", primary: false },
+      { domain, options: template.options, selected: value, primary: false },
     ]);
   };
 
@@ -51,43 +56,80 @@ export function AssessmentPanel({
   return (
     <Card title={domain}>
       <div className="stack stack--sm">
+        <div className="assessment-add-row">
+          <select
+            value={pickerValue}
+            onChange={(e) => {
+              const val = e.target.value;
+              if (!val) return;
+              if (items.some((a) => a.selected === val)) {
+                setPickerError("Already added.");
+              } else {
+                addAssessment(val);
+                setPickerError("");
+              }
+              setPickerValue("");
+            }}
+          >
+            <option value="">+ Add assessment...</option>
+            {options.map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+        </div>
+        <p className={`small${pickerError ? " text-danger" : ""}`}>
+          {pickerError || "Choose a tool to add it below."}
+        </p>
+        <hr className="assessment-divider" />
+        {items.length === 0 && (
+          <div className="assessment-placeholder">
+            No assessments added — select one above to get started.
+          </div>
+        )}
         {items.map((a) => (
-          <Row key={a.index} justify="between" align="center">
-            <label style={{ flex: 1 }}>
-              <select
-                value={a.selected || ""}
-                className={a.selected ? "" : "invalid"}
-                title={a.selected ? "" : "Select assessment"}
-                onChange={(e) => changeSelection(a.index, e.target.value)}
+          <div key={a.index} className="assessment-card">
+            <div className="assessment-card__header">
+              <span>{a.selected || "Select"}</span>
+              <button
+                type="button"
+                className={`badge${a.primary ? " badge--ok" : ""}`}
+                onClick={() => togglePrimary(a.index)}
               >
-                <option value="">Select</option>
-                {a.options.map((o) => (
-                  <option key={o} value={o}>
-                    {o}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="row row--center" style={{ gap: 4 }}>
-              <input
-                type="checkbox"
-                checked={a.primary || false}
-                onChange={() => togglePrimary(a.index)}
-              />
-              Main
-            </label>
-            {items.length > 1 && (
-              <button type="button" className="btn" onClick={() => removeAssessment(a.index)}>
-                Remove
+                Main
               </button>
-            )}
-          </Row>
+            </div>
+            <div className="assessment-card__body">
+              <label>
+                <select
+                  value={a.selected || ""}
+                  className={a.selected ? "" : "invalid"}
+                  title={a.selected ? "" : "Select assessment"}
+                  onChange={(e) => changeSelection(a.index, e.target.value)}
+                >
+                  <option value="">Select</option>
+                  {a.options.map((o) => (
+                    <option key={o} value={o}>
+                      {o}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <div className="assessment-card__footer">
+              {items.length > 1 && (
+                <button
+                  type="button"
+                  className="btn"
+                  onClick={() => removeAssessment(a.index)}
+                >
+                  × Remove
+                </button>
+              )}
+            </div>
+          </div>
         ))}
-        <Row>
-          <button type="button" className="btn" onClick={addAssessment}>
-            Add Assessment
-          </button>
-        </Row>
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary
- Add dedicated picker row with "+ Add assessment" placeholder and duplicate warnings
- Convert assessment entries to cards with top-right "Main" badge and remove action
- Introduce styles for picker, divider, cards, and placeholder states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d8f421b58832596d91a68d6ddcae5