### PR TITLE
feat: add dataset checklist and compact header

### DIFF
--- a/src/components/MinDatasetProgress.tsx
+++ b/src/components/MinDatasetProgress.tsx
@@ -1,14 +1,37 @@
 import React from "react";
 
-export function MinDatasetProgress({ count, total }: { count: number; total: number }) {
-  const pct = total ? Math.min(100, (count / total) * 100) : 0;
+export type MinDatasetItem = {
+  label: string;
+  met: boolean;
+  targetId?: string;
+};
+
+export function MinDatasetProgress({ items }: { items: MinDatasetItem[] }) {
+  const met = items.filter((i) => i.met).length;
+  const scrollTo = (id?: string) => {
+    if (!id) return;
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView({ behavior: "smooth" });
+  };
   return (
     <div className="stack stack--sm">
       <div className="row row--between">
-        <div>Minimum dataset: {count}/{total} met</div>
+        <div>
+          Minimum dataset ({met}/{items.length})
+        </div>
       </div>
-      <div className="progress-bar">
-        <div className="progress-bar__fill" style={{ width: `${pct}%` }} />
+      <div className="chip-row">
+        {items.map((item) => (
+          <button
+            key={item.label}
+            type="button"
+            className={"chip" + (item.met ? " chip--active" : "")}
+            aria-pressed={item.met}
+            onClick={() => scrollTo(item.targetId)}
+          >
+            {item.label}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -56,17 +56,24 @@ export function Header({
         </div>
 
         <div className="row" style={{ gap: 8 }}>
-          <button type="button" className="btn" onClick={onDevToggle} disabled={!onDevToggle}>
-            Dev
-          </button>
-          <button
-            type="button"
-            className="btn"
-            onClick={onExportSummary}
-            disabled={!onExportSummary}
-          >
-            Export summary
-          </button>
+          <label>
+            <select
+              defaultValue=""
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === "dev") onDevToggle?.();
+                if (v === "summary") onExportSummary?.();
+                e.target.value = "";
+              }}
+              title="More actions"
+            >
+              <option value="" disabled>
+                More
+              </option>
+              <option value="dev">Dev</option>
+              <option value="summary">Export summary</option>
+            </select>
+          </label>
           <button type="button" className="btn" onClick={onExportFull} disabled={!onExportFull}>
             Export (full)
           </button>


### PR DESCRIPTION
## Summary
- unify minimum dataset progress into a single checklist with scrollable chips
- collapse Dev and Export Summary controls into a dropdown toolbar

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d937fab7c83258878cff53a7f45e3