### PR TITLE
feat: improve summary and toolbar layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -617,6 +617,7 @@ export default function App() {
                   supportEstimate={supportEstimate}
                   recommendation={recommendation}
                   exportSummary={exportSummary}
+                  minDatasetItems={minDatasetItems}
                 />
               </section>
             </div>

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -50,11 +50,21 @@ export function Header({
           )}
         </div>
 
-        <div className="row row--wrap">
-          {onThemeToggle && <button className="btn" onClick={onThemeToggle}>{theme === "dark" ? "Day" : "Night"}</button>}
-          {onDevToggle && <button className="btn" onClick={onDevToggle}>Dev</button>}
-          {onExportSummary && <button className="btn" onClick={onExportSummary}>Export summary</button>}
-          {onExportFull && <button className="btn btn--accent" onClick={onExportFull}>Export (full)</button>}
+        <div className="toolbar">
+          {onThemeToggle && (
+            <button className="btn btn--sm" onClick={onThemeToggle}>
+              {theme === "dark" ? "Day" : "Night"}
+            </button>
+          )}
+          {onDevToggle && (
+            <button className="btn btn--sm" onClick={onDevToggle}>Dev</button>
+          )}
+          {onExportSummary && (
+            <button className="btn btn--sm" onClick={onExportSummary}>Export summary</button>
+          )}
+          {onExportFull && (
+            <button className="btn btn--accent" onClick={onExportFull}>Export (full)</button>
+          )}
         </div>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -84,6 +84,8 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .btn:hover{box-shadow:var(--shadow-2)}
 .btn--accent{background:var(--accent);border-color:transparent;color:#fff}
 .btn--accent:hover{filter:brightness(1.05)}
+.btn--sm{height:28px;padding:0 8px;font-size:12px}
+.toolbar{display:flex;gap:4px;flex-wrap:wrap}
 
 .tabbar{display:flex;gap:16px;flex-wrap:wrap}
 .tab{border:1px solid var(--border);background:var(--panel);border-radius:999px;padding:6px 12px;font-weight:500;color:var(--muted);transition:background-color var(--t-fast) var(--ease),color var(--t-fast) var(--ease)}

--- a/src/panels/SummaryPanel.tsx
+++ b/src/panels/SummaryPanel.tsx
@@ -1,13 +1,34 @@
 import { Card, Stack } from "../components/primitives";
+import type { MinDatasetItem } from "../components/MinDatasetProgress";
 
 export function SummaryPanel({
-  model, config, supportEstimate, recommendation, exportSummary
-}:{ model:any; config:any; supportEstimate:string; recommendation:string[]; exportSummary:()=>void }) {
+  model,
+  config,
+  supportEstimate,
+  recommendation,
+  exportSummary,
+  minDatasetItems,
+}:{
+  model: any;
+  config: any;
+  supportEstimate: string;
+  recommendation: string[];
+  exportSummary: () => void;
+  minDatasetItems: MinDatasetItem[];
+}) {
   const handleExport = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const v = e.target.value;
     if (v === "summary") exportSummary();
     if (v === "full") window.print();
     e.target.value = "";
+  };
+  const met = minDatasetItems.filter((i) => i.met).length;
+  const unmet = minDatasetItems.filter((i) => !i.met);
+  const percent = Math.round((met / minDatasetItems.length) * 100);
+  const scrollTo = (id?: string) => {
+    if (!id) return;
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView({ behavior: "smooth" });
   };
   return (
     <aside className="summary" style={{position:"sticky", top:0}}>
@@ -24,6 +45,26 @@ export function SummaryPanel({
               : <span className="badge badge--warn">Below threshold — consider more data</span>}
           </div>
           <div className="card" style={{textAlign:"center"}}>{supportEstimate}</div>
+          <div className="stack stack--sm">
+            <div className="row row--between small">
+              <div>Minimum dataset</div>
+              <div>{percent}%</div>
+            </div>
+            {unmet.length > 0 && (
+              <div className="chip-row">
+                {unmet.map((item) => (
+                  <button
+                    key={item.label}
+                    type="button"
+                    className="chip"
+                    onClick={() => scrollTo(item.targetId)}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
           <div className="row" style={{gap:8}}>
             <label style={{flex:1}}>
               <select defaultValue="" onChange={handleExport} title="Export options">


### PR DESCRIPTION
## Summary
- Add unified progress checklist chips for minimum dataset
- Display live minimum dataset percentage and unmet items in sticky summary panel
- Move Dev and Export actions into compact toolbar with smaller button styles

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d9d2f07448325a8c013cae7eb48ab