### PR TITLE
Enhance summary panel with decision clarity features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,6 +263,10 @@ export default function App() {
     }, 0);
   };
 
+  const handleRiskToleranceChange = (v: any) => {
+    setConfig((c) => ({ ...c, riskTolerance: v }));
+  };
+
   // ---------- rule signature ----------
   const ruleHash = useMemo(() => {
     const s = JSON.stringify(DEFAULT_CONFIG);
@@ -623,6 +627,7 @@ export default function App() {
                   recommendation={recommendation}
                   exportSummary={exportSummary}
                   minDatasetItems={minDatasetItems}
+                  onRiskToleranceChange={handleRiskToleranceChange}
                 />
               </section>
             </div>

--- a/src/panels/SummaryPanel.tsx
+++ b/src/panels/SummaryPanel.tsx
@@ -8,6 +8,7 @@ export function SummaryPanel({
   recommendation,
   exportSummary,
   minDatasetItems,
+  onRiskToleranceChange,
 }:{
   model: any;
   config: any;
@@ -15,6 +16,7 @@ export function SummaryPanel({
   recommendation: string[];
   exportSummary: () => void;
   minDatasetItems: MinDatasetItem[];
+  onRiskToleranceChange: (v: any) => void;
 }) {
   const handleExport = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const v = e.target.value;
@@ -30,6 +32,25 @@ export function SummaryPanel({
     const el = document.getElementById(id);
     if (el) el.scrollIntoView({ behavior: "smooth" });
   };
+
+  const drivers = (model.drivers || []).slice(0,3);
+  const suggestionFor = (label: string) => {
+    if (label === "Adaptive measure") return "Add an Adaptive measure (Vineland/ABAS)";
+    if (label === "ASD instrument") return "Add an ASD instrument (e.g., ADOS-2, CARS)";
+    if (label === "History") return "Gather developmental history";
+    if (label.startsWith("≥")) return "Increase instrument count";
+    return `Add ${label}`;
+  };
+  const suggestions = unmet.slice(0,2).map((i) => suggestionFor(i.label));
+  const hasInstrumentMix = minDatasetItems.find((i) => i.label.includes("instrument") && i.met);
+  const confidence =
+    percent === 100 ? "High" : percent >= 50 && hasInstrumentMix ? "Medium" : "Low";
+
+  const riskExplain: Record<string,string> = {
+    balanced: "50% cutpoint balances false positives and negatives.",
+    sensitive: "40% cutpoint favors sensitivity to catch more cases.",
+    specific: "60% cutpoint favors specificity to avoid false positives.",
+  };
   return (
     <aside className="summary" style={{position:"sticky", top:0}}>
       <Card title="Summary">
@@ -37,14 +58,38 @@ export function SummaryPanel({
           <div>
             <div style={{fontSize:32,fontWeight:800}}>{(model.p*100).toFixed(1)}%</div>
             <div className="small">Overall ASD likelihood</div>
-            <div className="small">Cutpoint: {(model.cut*100).toFixed(0)}% ({config.riskTolerance})</div>
+            <label className="small row" style={{gap:8,alignItems:"center"}}>
+              <span>Threshold:</span>
+              <select
+                value={config.riskTolerance}
+                onChange={(e) => onRiskToleranceChange(e.target.value)}
+              >
+                <option value="balanced">Balanced (50%)</option>
+                <option value="sensitive">Sensitivity-favored (40%)</option>
+                <option value="specific">Specificity-favored (60%)</option>
+              </select>
+            </label>
+            <div className="small">{riskExplain[config.riskTolerance]}</div>
           </div>
           <div>
             Decision: {model.p >= model.cut
               ? <span className="badge badge--ok">Above threshold — proceed</span>
               : <span className="badge badge--warn">Below threshold — consider more data</span>}
           </div>
-          <div className="card" style={{textAlign:"center"}}>{supportEstimate}</div>
+          <div className="row" style={{gap:8,alignItems:"center"}}>
+            <div className="card" style={{textAlign:"center",flex:1}}>{supportEstimate}</div>
+            <span className="badge">{confidence} confidence</span>
+          </div>
+          {drivers.length > 0 && (
+            <div>
+              <div className="small">Top contributors</div>
+              <ul className="small" style={{paddingLeft:16}}>
+                {drivers.map((d: any) => (
+                  <li key={d.name}>{d.name} {d.delta >=0 ? "+" : ""}{d.delta.toFixed(0)}%</li>
+                ))}
+              </ul>
+            </div>
+          )}
           <div className="stack stack--sm">
             <div className="row row--between small">
               <div>Minimum dataset</div>
@@ -65,6 +110,16 @@ export function SummaryPanel({
               </div>
             )}
           </div>
+          {suggestions.length > 0 && (
+            <div className="small">
+              <div>What to add next</div>
+              <ul style={{paddingLeft:16, marginTop:4}}>
+                {suggestions.map((s) => (
+                  <li key={s}>{s}</li>
+                ))}
+              </ul>
+            </div>
+          )}
           <div className="row" style={{gap:8}}>
             <label style={{flex:1}}>
               <select defaultValue="" onChange={handleExport} title="Export options">


### PR DESCRIPTION
## Summary
- display top contributing instruments with probability deltas
- provide suggestions for missing checklist items and confidence badge
- add threshold selector with updated cutpoints for sensitivity/specificity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dae87bc3883259fdd360e001767f8