### PR TITLE
Add history checklist and comorbidity toggles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,12 +88,12 @@ export default function App() {
     developmentalConcerns: "",
     earlyOnset: false,
     earlySocial: false,
-    earlyCommunication: false,
     earlyRRB: false,
     regression: false,
     crossContextImpairment: false,
     familyHistory: false,
     maskingIndicators: false,
+    verbalFluency: "",
   });
 
   const [observation, setObservation] = useState({
@@ -108,15 +108,12 @@ export default function App() {
   });
 
   const [diff, setDiff] = useState({
-    ADHD: false,
-    DLD: false,
-    ID: false,
-    Anxiety: false,
-    Depression: false,
-    TraumaPTSD: false,
-    FASD: false,
-    Tics: false,
-    Other: "",
+    adhdFeatures: false,
+    languageDisorder: false,
+    globalID: false,
+    anxietyPrimary: false,
+    ocdFeatures: false,
+    trauma: false,
   });
 
   const [clinician, setClinician] = useState({
@@ -628,6 +625,7 @@ export default function App() {
                   exportSummary={exportSummary}
                   minDatasetItems={minDatasetItems}
                   onRiskToleranceChange={handleRiskToleranceChange}
+                  history={history}
                 />
               </section>
             </div>

--- a/src/hooks/useAsdEngine.ts
+++ b/src/hooks/useAsdEngine.ts
@@ -17,12 +17,12 @@ export function useAsdEngine(
     developmentalConcerns: string;
     earlyOnset: boolean;
     earlySocial: boolean;
-    earlyCommunication: boolean;
     earlyRRB: boolean;
     regression: boolean;
     crossContextImpairment: boolean;
     familyHistory: boolean;
     maskingIndicators: boolean;
+    verbalFluency: string;
   },
   observation: Record<CriterionKey | "notes", any>,
   diff: Record<string, boolean | unknown>,
@@ -129,15 +129,14 @@ export function useAsdEngine(
     add("Early history", "onsetEarly", history.earlyOnset ? 1 : 0);
     add("Early history", "impairment", history.crossContextImpairment ? 1 : 0);
     add("Early history", "masking", history.maskingIndicators ? 1 : 0);
-    add("Differentials", "langDisorder", (diff as any).DLD ? 1 : 0);
-    add("Differentials", "intellectualDisability", (diff as any).ID ? 1 : 0);
-    add("Differentials", "altTrauma", (diff as any).TraumaPTSD ? 1 : 0);
-    add("Differentials", "altADHD", (diff as any).ADHD ? 1 : 0);
-    add("Differentials", "altAnxiety", (diff as any).Anxiety || (diff as any).Depression ? 1 : 0);
-    add("Differentials", "altOther", (diff as any).FASD || (diff as any).Tics || !!(diff as any).Other ? 1 : 0);
+    add("Differentials", "langDisorder", (diff as any).languageDisorder ? 1 : 0);
+    add("Differentials", "intellectualDisability", (diff as any).globalID ? 1 : 0);
+    add("Differentials", "altTrauma", (diff as any).trauma ? 1 : 0);
+    add("Differentials", "altADHD", (diff as any).adhdFeatures ? 1 : 0);
+    add("Differentials", "altAnxiety", (diff as any).anxietyPrimary ? 1 : 0);
+    add("Differentials", "altOther", (diff as any).ocdFeatures ? 1 : 0);
 
     add("Early history", "A1", history.earlySocial ? 0.6 : -0.2);
-    add("Early history", "A3", history.earlyCommunication ? 0.6 : -0.2);
     add("Early history", "B2", history.earlyRRB ? 0.6 : -0.2);
     if (history.regression) {
       add("Early history", "A1", 0.3);

--- a/src/panels/DiffPanel.tsx
+++ b/src/panels/DiffPanel.tsx
@@ -10,38 +10,29 @@ export function DiffPanel({
 }) {
   const update = (k: string, v: any) => setDiff((d: any) => ({ ...d, [k]: v }));
 
-  const items: [string, string][] = [
-    ["ADHD", "ADHD indicators"],
-    ["DLD", "Language disorder"],
-    ["ID", "Intellectual disability"],
-    ["Anxiety", "Anxiety/OCD"],
-    ["Depression", "Depression"],
-    ["TraumaPTSD", "Trauma/PTSD"],
-    ["FASD", "FASD"],
-    ["Tics", "Tics"],
+  const items: { key: string; label: string; tip: string }[] = [
+    { key: "adhdFeatures", label: "ADHD features", tip: "ADHD traits may overlap" },
+    { key: "languageDisorder", label: "Language disorder (structural)", tip: "Structural language issues" },
+    { key: "globalID", label: "Global ID", tip: "Global intellectual disability" },
+    { key: "anxietyPrimary", label: "Anxiety primary", tip: "Anxiety appears primary driver" },
+    { key: "ocdFeatures", label: "OCD features", tip: "Obsessive-compulsive traits" },
+    { key: "trauma", label: "Trauma", tip: "Significant trauma history" },
   ];
 
   return (
-    <Card title="Comorbidity / Differential">
+    <Card title="Comorbidity">
       <div className="stack stack--sm">
-        {items.map(([key, label]) => (
-          <label key={key}>
+        {items.map((item) => (
+          <label key={item.key} className="row" style={{ alignItems: "center", gap: 4 }}>
             <input
               type="checkbox"
-              checked={!!diff[key]}
-              onChange={(e) => update(key, e.target.checked)}
+              checked={!!diff[item.key]}
+              onChange={(e) => update(item.key, e.target.checked)}
             />
-            {label}
+            {item.label}
+            <span title={item.tip} style={{ marginLeft: 4 }}>?</span>
           </label>
         ))}
-        <label>
-          Other
-          <input
-            type="text"
-            value={diff.Other || ""}
-            onChange={(e) => update("Other", e.target.value)}
-          />
-        </label>
       </div>
     </Card>
   );

--- a/src/panels/HistoryPanel.tsx
+++ b/src/panels/HistoryPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Card } from "../components/primitives";
+import { VERBAL_FLUENCY_OPTIONS } from "../data/autismProfile";
 
 export function HistoryPanel({
   history,
@@ -11,12 +12,12 @@ export function HistoryPanel({
     developmentalConcerns: string;
     earlyOnset: boolean;
     earlySocial: boolean;
-    earlyCommunication: boolean;
     earlyRRB: boolean;
     regression: boolean;
     crossContextImpairment: boolean;
     familyHistory: boolean;
     maskingIndicators: boolean;
+    verbalFluency: string;
   };
   setHistory: (fn: (h: any) => any) => void;
   observation: Record<string, any>;
@@ -28,6 +29,59 @@ export function HistoryPanel({
 
   return (
     <div className="stack stack--md">
+      <Card title="History quick checklist">
+        <div className="stack stack--sm">
+          <label>
+            <input
+              type="checkbox"
+              checked={history.earlyOnset}
+              onChange={(e) => updateHistory("earlyOnset", e.target.checked)}
+            />
+            Onset <3y
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.regression}
+              onChange={(e) => updateHistory("regression", e.target.checked)}
+            />
+            Regression
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.earlySocial}
+              onChange={(e) => updateHistory("earlySocial", e.target.checked)}
+            />
+            Early social signs
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.earlyRRB}
+              onChange={(e) => updateHistory("earlyRRB", e.target.checked)}
+            />
+            Early RRB
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.crossContextImpairment}
+              onChange={(e) => updateHistory("crossContextImpairment", e.target.checked)}
+            />
+            Cross-setting
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={history.familyHistory}
+              onChange={(e) => updateHistory("familyHistory", e.target.checked)}
+            />
+            Family history
+          </label>
+        </div>
+      </Card>
+
       <Card title="Developmental History">
         <div className="stack stack--sm">
           <label>
@@ -40,66 +94,24 @@ export function HistoryPanel({
           <label>
             <input
               type="checkbox"
-              checked={history.earlyOnset}
-              onChange={(e) => updateHistory("earlyOnset", e.target.checked)}
-            />
-            Symptom onset before 3 years
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={history.earlySocial}
-              onChange={(e) => updateHistory("earlySocial", e.target.checked)}
-            />
-            Early social delays
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={history.earlyCommunication}
-              onChange={(e) => updateHistory("earlyCommunication", e.target.checked)}
-            />
-            Early communication delays
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={history.earlyRRB}
-              onChange={(e) => updateHistory("earlyRRB", e.target.checked)}
-            />
-            Early restricted or repetitive behaviours
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={history.regression}
-              onChange={(e) => updateHistory("regression", e.target.checked)}
-            />
-            Regression in language or social skills
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={history.crossContextImpairment}
-              onChange={(e) => updateHistory("crossContextImpairment", e.target.checked)}
-            />
-            Consistent symptoms across environments
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={history.familyHistory}
-              onChange={(e) => updateHistory("familyHistory", e.target.checked)}
-            />
-            Family history of ASD or related conditions
-          </label>
-          <label>
-            <input
-              type="checkbox"
               checked={history.maskingIndicators}
               onChange={(e) => updateHistory("maskingIndicators", e.target.checked)}
             />
             Masking indicators
+          </label>
+          <label className="stack stack--xs">
+            <div className="section-title">Verbal fluency</div>
+            <select
+              value={history.verbalFluency}
+              onChange={(e) => updateHistory("verbalFluency", e.target.value)}
+            >
+              <option value=""></option>
+              {VERBAL_FLUENCY_OPTIONS.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
           </label>
         </div>
       </Card>

--- a/src/panels/SummaryPanel.tsx
+++ b/src/panels/SummaryPanel.tsx
@@ -9,6 +9,7 @@ export function SummaryPanel({
   exportSummary,
   minDatasetItems,
   onRiskToleranceChange,
+  history,
 }:{
   model: any;
   config: any;
@@ -17,6 +18,7 @@ export function SummaryPanel({
   exportSummary: () => void;
   minDatasetItems: MinDatasetItem[];
   onRiskToleranceChange: (v: any) => void;
+  history: { maskingIndicators: boolean; verbalFluency: string };
 }) {
   const handleExport = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const v = e.target.value;
@@ -80,6 +82,19 @@ export function SummaryPanel({
             <div className="card" style={{textAlign:"center",flex:1}}>{supportEstimate}</div>
             <span className="badge">{confidence} confidence</span>
           </div>
+          {(history.maskingIndicators || history.verbalFluency) && (
+            <div className="chip-row">
+              {history.maskingIndicators && (
+                <span className="chip chip--active">Masking</span>
+              )}
+              {history.verbalFluency && (
+                <span className="chip chip--active">{history.verbalFluency}</span>
+              )}
+            </div>
+          )}
+          {history.maskingIndicators && (
+            <div className="small">Weights adjusted for masking</div>
+          )}
           {drivers.length > 0 && (
             <div>
               <div className="small">Top contributors</div>


### PR DESCRIPTION
## Summary
- add neuro-affirming history quick checklist and verbal fluency field
- replace differential panel with comorbidity toggles and guidance
- surface masking and fluency chips in summary with masking note

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689db0a4a80483258658be345cec14d1