### PR TITLE
Improve accessibility and export options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,8 @@ const initSeverityState = (domains: { key: string }[]): SeverityState =>
 
 export default function App() {
   useClickSound();
+  const VERSION = "v0.6";
+  const [exportTimestamp, setExportTimestamp] = useState("");
   // ---------- condition ----------
   const [condition, setCondition] = useState<Condition>("ASD");
 
@@ -251,13 +253,19 @@ export default function App() {
     ];
   }, [datasetStatus, config.minDataset]);
 
-  // ---------- summary print ----------
+  // ---------- summary/full export ----------
   const exportSummary = () => {
+    setExportTimestamp(new Date().toLocaleString());
     document.body.classList.add("print-summary");
     setTimeout(() => {
       window.print();
       setTimeout(() => document.body.classList.remove("print-summary"), 0);
     }, 0);
+  };
+  const exportFull = () => {
+    setExportTimestamp(new Date().toLocaleString());
+    document.body.classList.remove("print-summary");
+    window.print();
   };
 
   const handleRiskToleranceChange = (v: any) => {
@@ -280,9 +288,11 @@ export default function App() {
         subtitle="DSM-5-TR aligned • tabs build"
         onDevToggle={() => setDevOpen((v) => !v)}
         onExportSummary={exportSummary}
-        onExportFull={() => window.print()}
+        onExportFull={exportFull}
         condition={condition}
         onConditionChange={setCondition}
+        version={VERSION}
+        timestamp={exportTimestamp}
       />
 
       {condition === "ASD" ? (
@@ -623,6 +633,9 @@ export default function App() {
                   supportEstimate={supportEstimate}
                   recommendation={recommendation}
                   exportSummary={exportSummary}
+                  exportFull={exportFull}
+                  version={VERSION}
+                  timestamp={exportTimestamp}
                   minDatasetItems={minDatasetItems}
                   onRiskToleranceChange={handleRiskToleranceChange}
                   history={history}
@@ -634,7 +647,7 @@ export default function App() {
           <Card title={`${condition} assessments`}>Assessments for {condition} will be added soon.</Card>
         )}
 
-        <Footer version="v0.6" ruleHash={ruleHash} />
+        <Footer version={VERSION} ruleHash={ruleHash} />
         <AiChat />
       </Container>
     );

--- a/src/components/MinDatasetProgress.tsx
+++ b/src/components/MinDatasetProgress.tsx
@@ -27,6 +27,7 @@ export function MinDatasetProgress({ items }: { items: MinDatasetItem[] }) {
             type="button"
             className={"chip" + (item.met ? " chip--active" : "")}
             aria-pressed={item.met}
+            aria-label={item.label}
             onClick={() => scrollTo(item.targetId)}
           >
             {item.label}

--- a/src/components/chipGroup.tsx
+++ b/src/components/chipGroup.tsx
@@ -39,6 +39,7 @@ export function ChipGroup({
             style={style}
             onClick={() => onChange(String(opt))}
             aria-pressed={selected}
+            aria-label={String(opt)}
           >
             {opt}
           </button>

--- a/src/components/primitives.tsx
+++ b/src/components/primitives.tsx
@@ -35,15 +35,16 @@ export const Button = ({ kind="neutral", children, ...props }:{
   <button className={`btn ${kind==="primary" ? "btn--accent":""}`} {...props}>{children}</button>;
 
 export const Chip = ({
-  active, children, onClick, activeBg, activeColor
+  active, children, activeBg, activeColor, ...props
 }:{
-  active?: boolean; children: React.ReactNode; onClick?: ()=>void;
+  active?: boolean; children: React.ReactNode;
   activeBg?: string; activeColor?: string;
-}) => (
+} & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
   <button
     className={`chip ${active ? "chip--active":""}`}
-    onClick={onClick}
     style={active ? { background: activeBg, color: activeColor } : undefined}
+    aria-pressed={active}
+    {...props}
   >
     {children}
   </button>

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -12,9 +12,17 @@ export type HeaderProps = {
   theme?: "dark" | "light";
   condition?: Condition;
   onConditionChange?: (c: Condition) => void;
+  version: string;
+  timestamp: string;
 };
 
 const CONDITIONS: Condition[] = ["ASD", "ADHD", "ID", "FASD"];
+const CONDITION_TITLES: Record<Condition, string> = {
+  ASD: "Autism Spectrum Disorder",
+  ADHD: "Attention-Deficit/Hyperactivity Disorder",
+  ID: "Intellectual Disability",
+  FASD: "Fetal Alcohol Spectrum Disorder",
+};
 
 export function Header({
   title,
@@ -26,6 +34,8 @@ export function Header({
   theme = "dark",
   condition,
   onConditionChange,
+  version,
+  timestamp,
 }: HeaderProps) {
   return (
     <div className="topbar">
@@ -33,6 +43,7 @@ export function Header({
         <div className="stack stack--sm">
           <h1 className="title">{title}</h1>
           {subtitle ? <div className="subtitle">{subtitle}</div> : null}
+          <div className="print-only small">Generated {timestamp} • Version {version}</div>
 
           {onConditionChange && (
             <div className="row row--wrap">
@@ -41,7 +52,9 @@ export function Header({
                   key={c}
                   className={`chip ${condition === c ? "chip--active" : ""}`}
                   onClick={() => onConditionChange(c)}
-                  title={c}
+                  title={CONDITION_TITLES[c]}
+                  aria-label={CONDITION_TITLES[c]}
+                  aria-pressed={condition === c}
                 >
                   {c}
                 </button>
@@ -125,16 +138,18 @@ export function ChipGroup({
         const active = value === opt;
         const bg = active && getColor ? getColor(opt) : undefined;
         return (
-          <button
-            key={opt}
-            onClick={() => onChange(opt)}
-            className={`chip ${active ? "chip--active" : ""}`}
-            style={bg ? { background: bg, color: "var(--text)" } : undefined}
-          >
-            {opt}
-          </button>
-        );
-      })}
+        <button
+          key={opt}
+          onClick={() => onChange(opt)}
+          className={`chip ${active ? "chip--active" : ""}`}
+          style={bg ? { background: bg, color: "var(--text)" } : undefined}
+          aria-pressed={active}
+          aria-label={opt}
+        >
+          {opt}
+        </button>
+      );
+    })}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,9 @@
   .tone-warn    { background:#fde68a; color:#78350f; border-color:#fde68a; }
   .tone-danger  { background:#fecaca; color:#7f1d1d; border-color:#fecaca; }
 
+  .print-only { display:none; }
+  @media print { .print-only { display:block; } }
+
 /* ===== App layout ===== */
 .app-shell{max-width:1120px;margin:32px auto;padding:0 24px 48px}
 /* wider column gap for a calmer layout */
@@ -51,7 +54,7 @@ body{
 }
 a,button{transition:color var(--t-fast) var(--ease),background-color var(--t-fast) var(--ease),border-color var(--t-fast) var(--ease),box-shadow var(--t-fast) var(--ease),transform var(--t-fast) var(--ease)}
 /* neutral button baseline */
-button{background:transparent;color:inherit;border:1px solid transparent;border-radius:10px;padding:8px 12px;font-weight:600;cursor:pointer}
+button{background:transparent;color:inherit;border:1px solid transparent;border-radius:10px;padding:8px 12px;font-weight:600;cursor:pointer;min-width:44px;min-height:44px}
 button:hover{transform:translateY(-1px) scale(1.02)}
 button:active{transform:scale(0.97)}
 button:disabled{opacity:.6;cursor:not-allowed}
@@ -82,11 +85,11 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .card-title{font-size:14px;font-weight:600;color:var(--text);margin:0 0 4px 0}
 .helper-text{font-size:12px;color:var(--muted);margin:0 0 12px 0}
 
-.btn{height:34px;padding:0 12px;border:1px solid var(--border);background:var(--panel);color:var(--text);border-radius:10px;box-shadow:var(--shadow-1)}
+.btn{min-height:44px;padding:0 12px;border:1px solid var(--border);background:var(--panel);color:var(--text);border-radius:10px;box-shadow:var(--shadow-1)}
 .btn:hover{box-shadow:var(--shadow-2)}
 .btn--accent{background:var(--accent);border-color:transparent;color:#fff}
 .btn--accent:hover{filter:brightness(1.05)}
-.btn--sm{height:28px;padding:0 8px;font-size:12px}
+.btn--sm{padding:0 8px;font-size:12px}
 .toolbar{display:flex;gap:4px;flex-wrap:wrap}
 
 .tabbar{display:flex;gap:16px;flex-wrap:wrap}
@@ -100,6 +103,9 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .badge--ok{background:var(--tone-good);border:1px solid color-mix(in hsl, var(--tone-good) 60%, black 40%)}
 .badge--warn{background:var(--tone-warn);border:1px solid color-mix(in hsl, var(--tone-warn) 60%, black 40%)}
 .badge--danger{background:var(--tone-danger);border:1px solid color-mix(in hsl, var(--tone-danger) 60%, black 40%)}
+.badge--ok::before{content:"\2713";margin-right:4px}
+.badge--warn::before{content:"\26A0";margin-right:4px}
+.badge--danger::before{content:"\2717";margin-right:4px}
 
 /* assessment picker & cards */
 .assessment-add-row{display:grid;gap:4px;background:color-mix(in hsl,var(--accent) 14%,transparent);border:1px solid var(--accent);border-radius:12px;padding:12px}
@@ -116,7 +122,7 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .progress-bar{width:100%;height:8px;background:var(--tone-neutral);border-radius:4px;overflow:hidden}
 .progress-bar__fill{height:100%;background:var(--accent-2)}
 
-input,select{padding:4px 6px;font-size:14px;width:100%}
+input,select{padding:4px 6px;font-size:14px;width:100%;min-height:44px}
 .invalid{border:1px solid var(--tone-danger)}
 
 /* floating chat */

--- a/src/panels/AssessmentPanel.tsx
+++ b/src/panels/AssessmentPanel.tsx
@@ -116,6 +116,8 @@ export function AssessmentPanel({
                 type="button"
                 className={`badge${a.primary ? " badge--ok" : ""}`}
                 onClick={() => togglePrimary(a.index)}
+                aria-pressed={a.primary}
+                aria-label="Toggle main assessment"
               >
                 Main
               </button>

--- a/src/panels/SummaryPanel.tsx
+++ b/src/panels/SummaryPanel.tsx
@@ -7,6 +7,9 @@ export function SummaryPanel({
   supportEstimate,
   recommendation,
   exportSummary,
+  exportFull,
+  version,
+  timestamp,
   minDatasetItems,
   onRiskToleranceChange,
   history,
@@ -16,6 +19,9 @@ export function SummaryPanel({
   supportEstimate: string;
   recommendation: string[];
   exportSummary: () => void;
+  exportFull: () => void;
+  version: string;
+  timestamp: string;
   minDatasetItems: MinDatasetItem[];
   onRiskToleranceChange: (v: any) => void;
   history: { maskingIndicators: boolean; verbalFluency: string };
@@ -23,7 +29,7 @@ export function SummaryPanel({
   const handleExport = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const v = e.target.value;
     if (v === "summary") exportSummary();
-    if (v === "full") window.print();
+    if (v === "full") exportFull();
     e.target.value = "";
   };
   const met = minDatasetItems.filter((i) => i.met).length;
@@ -54,7 +60,8 @@ export function SummaryPanel({
     specific: "60% cutpoint favors specificity to avoid false positives.",
   };
   return (
-    <aside className="summary" style={{position:"sticky", top:0}}>
+    <aside className="summary" id="summary-section" style={{position:"sticky", top:0}}>
+      <div className="print-only small" style={{marginBottom:8}}>Generated {timestamp} • Version {version}</div>
       <Card title="Summary">
         <Stack>
           <div>
@@ -85,10 +92,10 @@ export function SummaryPanel({
           {(history.maskingIndicators || history.verbalFluency) && (
             <div className="chip-row">
               {history.maskingIndicators && (
-                <span className="chip chip--active">Masking</span>
+                <span className="chip chip--active" role="status" aria-label="Masking">Masking</span>
               )}
               {history.verbalFluency && (
-                <span className="chip chip--active">{history.verbalFluency}</span>
+                <span className="chip chip--active" role="status" aria-label={history.verbalFluency}>{history.verbalFluency}</span>
               )}
             </div>
           )}
@@ -98,7 +105,7 @@ export function SummaryPanel({
           {drivers.length > 0 && (
             <div>
               <div className="small">Top contributors</div>
-              <ul className="small" style={{paddingLeft:16}}>
+              <ul className="small" style={{paddingLeft:16}} aria-label="Top drivers">
                 {drivers.map((d: any) => (
                   <li key={d.name}>{d.name} {d.delta >=0 ? "+" : ""}{d.delta.toFixed(0)}%</li>
                 ))}
@@ -118,6 +125,7 @@ export function SummaryPanel({
                     type="button"
                     className="chip"
                     onClick={() => scrollTo(item.targetId)}
+                    aria-label={item.label}
                   >
                     {item.label}
                   </button>
@@ -141,11 +149,11 @@ export function SummaryPanel({
                 <option value="" disabled>
                   Export...
                 </option>
-                <option value="summary" title="Export only the summary view">
-                  Summary
+                <option value="summary" title="Export key findings and drivers">
+                  Summary report (key findings & drivers)
                 </option>
-                <option value="full" title="Export the full report">
-                  Full
+                <option value="full" title="Export all inputs and scores">
+                  Full report (all inputs & scores)
                 </option>
               </select>
             </label>


### PR DESCRIPTION
## Summary
- enforce 44x44px targets and add icon-based status cues
- add ARIA labels to chips, toggles, and driver summaries
- clarify export options and include timestamp/version in printed reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689db6f100148325a242e055e93c5616