### PR TITLE
feat: add initial FASD panels

### DIFF
--- a/src/data/testData.ts
+++ b/src/data/testData.ts
@@ -423,3 +423,16 @@ export function validateTestData(): string[] {
 
   return problems;
 }
+// ----------------------------- FASD Neurobehavioral -----------------------------
+export const FASD_NEURO_SEVERITIES = ["Severe", "Moderate", "Typical"] as const;
+
+export const FASD_NEURO_DOMAINS: DomainLabelConfig[] = [
+  { key: "fasd_executive_function", label: "Executive Function", severities: FASD_NEURO_SEVERITIES },
+  { key: "fasd_attention", label: "Attention", severities: FASD_NEURO_SEVERITIES },
+  { key: "fasd_learning_academic", label: "Learning/Academic", severities: FASD_NEURO_SEVERITIES },
+  { key: "fasd_memory", label: "Memory", severities: FASD_NEURO_SEVERITIES },
+  { key: "fasd_language", label: "Language", severities: FASD_NEURO_SEVERITIES },
+  { key: "fasd_visuospatial", label: "Visuospatial", severities: FASD_NEURO_SEVERITIES },
+  { key: "fasd_motor", label: "Motor", severities: FASD_NEURO_SEVERITIES },
+  { key: "fasd_social_emotional", label: "Social/Emotional Regulation", severities: FASD_NEURO_SEVERITIES },
+];

--- a/src/panels/ExposurePanel.tsx
+++ b/src/panels/ExposurePanel.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Card } from "../components/primitives";
+
+export type ExposureState = {
+  pae_level: string;
+  timing: string[];
+  source: string[];
+};
+
+const TIMING = [
+  { key: "trimester1", label: "Trimester 1" },
+  { key: "trimester2", label: "Trimester 2" },
+  { key: "trimester3", label: "Trimester 3" },
+  { key: "binge_patterns", label: "Binge patterns" },
+];
+
+const SOURCE = [
+  { key: "biological_parent_report", label: "Biological parent report" },
+  { key: "collateral", label: "Collateral" },
+  { key: "records", label: "Records" },
+  { key: "biomarker", label: "Biomarker" },
+];
+
+export function ExposurePanel({ state, setState }:{
+  state: ExposureState;
+  setState: (fn: (s: ExposureState) => ExposureState) => void;
+}) {
+  const toggle = (arr: string[], key: string) =>
+    arr.includes(key) ? arr.filter((k) => k !== key) : [...arr, key];
+
+  return (
+    <Card title="Exposure">
+      <div className="stack stack--md">
+        <label>
+          Prenatal alcohol exposure
+          <select
+            value={state.pae_level}
+            onChange={(e) => setState((s) => ({ ...s, pae_level: e.target.value }))}
+          >
+            <option value="">Select</option>
+            <option value="confirmed_heavy">Confirmed heavy</option>
+            <option value="confirmed_some">Confirmed some</option>
+            <option value="unknown">Unknown</option>
+            <option value="denied">Denied</option>
+          </select>
+        </label>
+
+        <fieldset>
+          <legend className="small">Timing</legend>
+          <div className="row row--wrap" style={{ gap: 8 }}>
+            {TIMING.map((t) => (
+              <label key={t.key} className="chip" style={{ cursor: "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={state.timing.includes(t.key)}
+                  onChange={() => setState((s) => ({ ...s, timing: toggle(s.timing, t.key) }))}
+                />
+                {t.label}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend className="small">Source</legend>
+          <div className="row row--wrap" style={{ gap: 8 }}>
+            {SOURCE.map((t) => (
+              <label key={t.key} className="chip" style={{ cursor: "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={state.source.includes(t.key)}
+                  onChange={() => setState((s) => ({ ...s, source: toggle(s.source, t.key) }))}
+                />
+                {t.label}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      </div>
+    </Card>
+  );
+}
+
+export default ExposurePanel;

--- a/src/panels/FacialGrowthPanel.tsx
+++ b/src/panels/FacialGrowthPanel.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Card } from "../components/primitives";
+
+export type FacialGrowthState = {
+  sentinel_features_count: number;
+  pfl_percentile: string;
+  philtrum_rank: string;
+  upper_lip_thin_rank: string;
+  growth_deficiency: boolean;
+};
+
+export function FacialGrowthPanel({ state, setState }:{
+  state: FacialGrowthState;
+  setState: (fn: (s: FacialGrowthState) => FacialGrowthState) => void;
+}) {
+  return (
+    <Card title="Facial & Growth">
+      <div className="stack stack--md">
+        <label>
+          Sentinel features
+          <select
+            value={state.sentinel_features_count}
+            onChange={(e) =>
+              setState((s) => ({ ...s, sentinel_features_count: Number(e.target.value) }))
+            }
+          >
+            {[0,1,2,3].map((n) => (
+              <option key={n} value={n}>{n}</option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          PFL percentile
+          <input
+            type="number"
+            value={state.pfl_percentile}
+            onChange={(e) => setState((s) => ({ ...s, pfl_percentile: e.target.value }))}
+          />
+        </label>
+
+        <label>
+          Philtrum rank
+          <input
+            type="number"
+            value={state.philtrum_rank}
+            onChange={(e) => setState((s) => ({ ...s, philtrum_rank: e.target.value }))}
+          />
+        </label>
+
+        <label>
+          Upper lip thin rank
+          <input
+            type="number"
+            value={state.upper_lip_thin_rank}
+            onChange={(e) => setState((s) => ({ ...s, upper_lip_thin_rank: e.target.value }))}
+          />
+        </label>
+
+        <label className="row" style={{gap:8,alignItems:"center"}}>
+          <input
+            type="checkbox"
+            checked={state.growth_deficiency}
+            onChange={(e) => setState((s) => ({ ...s, growth_deficiency: e.target.checked }))}
+          />
+          <span>Growth deficiency (≤10th %ile)</span>
+        </label>
+      </div>
+    </Card>
+  );
+}
+
+export default FacialGrowthPanel;


### PR DESCRIPTION
## Summary
- add exposure entry panel with timing and source selectors
- add facial/growth data panel for sentinel features and growth deficiency
- define neurobehavioral domain labels for FASD assessments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dd0d299a08325b3cb29dd399da558