### PR TITLE
Add FASD neurobehavioral panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   BRIEF2_DOMAINS,
   SENSORY_PROFILE_DOMAINS,
   CELF5_DOMAINS,
+  FASD_NEURO_DOMAINS,
 } from "./data/testData";
 import type { Config, SeverityState, Condition, AssessmentSelection, ClientProfile } from "./types";
 
@@ -35,6 +36,7 @@ import { DomainPanel } from "./panels/DomainPanel";
 import { HistoryPanel } from "./panels/HistoryPanel";
 import { DiffPanel } from "./panels/DiffPanel";
 import { AiChat } from "./components/AiChat";
+import { FasdPanel } from "./panels/FasdPanel";
 
 const initSeverityState = (domains: { key: string }[]): SeverityState =>
   Object.fromEntries(domains.map((d) => [d.key, { score: undefined, severity: "" }])) as SeverityState;
@@ -78,6 +80,7 @@ export default function App() {
   const [brief, setBRIEF] = useState<SeverityState>(() => initSeverityState(BRIEF2_DOMAINS));
   const [sensory, setSensory] = useState<SeverityState>(() => initSeverityState(SENSORY_PROFILE_DOMAINS));
   const [celf, setCELF] = useState<SeverityState>(() => initSeverityState(CELF5_DOMAINS));
+  const [fasdNeuro, setFasdNeuro] = useState<SeverityState>(() => initSeverityState(FASD_NEURO_DOMAINS));
 
   const [migdas, setMIGDAS] = useState({
     consistency: (MIGDAS_CONSISTENCY[0] as (typeof MIGDAS_CONSISTENCY)[number]) || "unclear",
@@ -674,8 +677,14 @@ export default function App() {
               </section>
             </div>
           </>
+        ) : condition === "FASD" ? (
+          <div className="stack stack--lg">
+            <FasdPanel valueMap={fasdNeuro} setValueMap={setFasdNeuro} />
+          </div>
         ) : (
-          <Card title={`${condition} assessments`}>Assessments for {condition} will be added soon.</Card>
+          <Card title={`${condition} assessments`}>
+            Assessments for {condition} will be added soon.
+          </Card>
         )}
 
         <Footer version={VERSION} ruleHash={ruleHash} />

--- a/src/panels/FasdPanel.tsx
+++ b/src/panels/FasdPanel.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import type { SeverityState } from "../types";
+import { DomainPanel } from "./DomainPanel";
+import { FASD_NEURO_DOMAINS } from "../data/testData";
+
+export function FasdPanel({
+  valueMap,
+  setValueMap,
+}: {
+  valueMap: SeverityState;
+  setValueMap: (fn: (s: SeverityState) => SeverityState) => void;
+}) {
+  return (
+    <DomainPanel
+      title="Neurobehavioral impairment"
+      domains={FASD_NEURO_DOMAINS}
+      valueMap={valueMap}
+      setValueMap={setValueMap}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Create FASD neurobehavioral panel and state management
- Route FASD tab to new panel instead of placeholder

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dd4047d2c8325b8248e141cef2bc3