### PR TITLE
fix: remove stray closing fragment in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -623,7 +623,6 @@ export default function App() {
               </section>
             </div>
           )}
-        </>
 
         <Footer version={VERSION} ruleHash={ruleHash} />
         <AiChat />


### PR DESCRIPTION
## Summary
- remove stray closing fragment in App.tsx to fix build
- ensure footer and chat render inside Container

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689effb78b68832583088f3649443da0