### PR TITLE
feat: add pathway controls to summary panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { AbasPanel } from "./panels/AbasPanel";
 import { SummaryPanel } from "./panels/SummaryPanel";
 import { VinelandPanel } from "./panels/VinelandPanel";
 import { AssessmentSelector } from "./components/AssessmentSelector";
+import { MinDatasetProgress } from "./components/MinDatasetProgress";
 import { ReportPanel } from "./panels/ReportPanel";
 import { GenericInstrumentPanel } from "./panels/GenericInstrumentPanel";
 import { DomainPanel } from "./panels/DomainPanel";
@@ -288,6 +289,9 @@ export default function App() {
         version={VERSION}
         timestamp={exportTimestamp}
       />
+      <div style={{ position: "sticky", top: 0, background: "var(--bg)", zIndex: 5 }}>
+        <MinDatasetProgress items={minDatasetItems} />
+      </div>
       <Card title="Client">
         <div className="row row--wrap" style={{ gap: 8 }}>
           <label style={{ flex: 1 }}>

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -30,7 +30,7 @@ export const VINELAND_IMPAIRMENT_MAP: Record<(typeof VINELAND_SEVERITIES)[number
 
 export const DEFAULT_CONFIG: Config = {
   prior: 0,
-  certaintyThreshold: 0.9,
+  certaintyThreshold: 0.5,
   domainWeights: {
     A1: 0.5,
     A2: 0.48,

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export type InstrumentEntry = {
 
 export type Config = {
   prior: number;
-  certaintyThreshold: 0.8 | 0.9 | 0.99;
+  certaintyThreshold: 0.4 | 0.5 | 0.6 | 0.8 | 0.9 | 0.99;
   domainWeights: Record<CriterionKey | AltKey, number>;
   minDataset: MinDatasetRules;
   defaultInstruments: InstrumentConfig[];


### PR DESCRIPTION
## Summary
- add pathway selection chips with primary toggle and threshold options in summary panel
- expose minimum dataset progress under header for quick access
- update configuration types and defaults for new threshold selector

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f0aa30f1c83258524fb7a6b91c2c0