### PR TITLE
Remove preset packs and reorganize assessment categories

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,14 +159,59 @@ export default function App() {
 
   // ---------- assessment selections ----------
   const [assessments, setAssessments] = useState<AssessmentSelection[]>([
-    { domain: "Autism questionnaires", options: ["ASRS", "SRS-2", "GARS", "CARS", "AQ"] },
-    { domain: "Autism observations", options: ["MIGDAS", "ADOS"] },
+    {
+      domain: "Autism questionnaires",
+      options: ["ASRS", "SRS-2", "GARS", "CARS", "AQ", "ADOS", "ADI-R"],
+    },
+    { domain: "Autism observations", options: ["MIGDAS", "ADOS", "CARS"] },
     { domain: "Autism interviews", options: ["ADI-R"] },
     { domain: "Adaptive questionnaires", options: ["ABAS3", "Vineland"] },
-    { domain: "Executive function questionnaires", options: ["BRIEF2", "BDEFS"] },
+    {
+      domain: "Executive function questionnaires",
+      options: [
+        "BRIEF2",
+        "BDEFS",
+        "Conners-4",
+        "Conners-3",
+        "Conners-EC",
+        "Conners CBRS",
+        "Vanderbilt ADHD Rating Scales",
+        "CPT-3",
+        "D-KEFS",
+        "NEPSY-II (Inhibition)",
+        "NEPSY-II (Statue)",
+      ],
+    },
     { domain: "Intellectual assessment", options: ["WISC", "WPPSI", "WAIS"] },
     { domain: "Language assessment", options: ["CELF5"] },
-    { domain: "Sensory Assessment", options: ["Sensory profile 2"] },
+    {
+      domain: "Sensory Assessment",
+      options: [
+        "Sensory profile 2",
+        "MIGDAS",
+        "ADOS",
+        "CARS",
+        "SRS-2",
+        "GARS",
+        "AQ",
+      ],
+    },
+    { domain: "Academic assessment", options: ["WIAT-III"] },
+    {
+      domain: "Memory assessment",
+      options: ["WRAML2", "CMS", "CVLT-C", "NEPSY-II (Memory for Designs)"] },
+    {
+      domain: "Motor/Visuospatial assessment",
+      options: [
+        "Beery VMI",
+        "BOT-2",
+        "NEPSY-II (Visuomotor)",
+        "NEPSY-II (Statue)",
+        "WISC-V Visual Spatial Index",
+      ],
+    },
+    { domain: "History", options: ["History Profile", "ADI-R"] },
+    { domain: "FASD Core", options: ["Exposure (PAE)", "Facial/Growth"] },
   ]);
 
   const NAME_MAP: Record<string, string> = {
@@ -180,6 +225,8 @@ export default function App() {
     WAIS: "WISC/WAIS/WPPSI",
     "Sensory profile 2": "Sensory Profile 2",
     CELF5: "CELF-5",
+    GARS: "GARS-3",
+    CARS: "CARS-2",
   };
 
   const getSelectedNames = useCallback(

--- a/src/components/QuickAddPresets.tsx
+++ b/src/components/QuickAddPresets.tsx
@@ -13,8 +13,6 @@ const INSTRUMENT_DOMAIN: Record<string, string> = {
 };
 
 const PRESETS: Record<string, string[]> = {
-  core: ["SRS-2", "ADOS", "ADI-R", "Vineland"],
-  questionnaires: ["SRS-2", "ASRS", "ABAS3", "BRIEF2"],
   observation: ["ADOS", "MIGDAS"],
 };
 
@@ -47,8 +45,6 @@ export function QuickAddPresets({
 
   return (
     <div className="pill-row" style={{ marginBottom: "8px" }}>
-      <button type="button" className="pill" onClick={() => handlePreset("core")}>Core pack</button>
-      <button type="button" className="pill" onClick={() => handlePreset("questionnaires")}>Questionnaires</button>
       <button type="button" className="pill" onClick={() => handlePreset("observation")}>Observation</button>
     </div>
   );


### PR DESCRIPTION
## Summary
- drop Core and Questionnaire preset packs from selection components
- expand assessment list with detailed categories and cross-listed instruments
- map new categories for filtering in the assessment selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f13df48048325942915311b53a1af