### PR TITLE
Display condition likelihoods with scalable circles

### DIFF
--- a/src/components/ConditionGlyph.tsx
+++ b/src/components/ConditionGlyph.tsx
@@ -1,11 +1,9 @@
-import React, { useMemo } from "react";
+import React from "react";
 
 export type ConditionGlyphProps = {
   label: string;
   color: string;
   posteriorPct: number; // 0..1
-  completenessPct: number; // 0..1
-  confidence: string;
   badges?: string[];
 };
 
@@ -13,51 +11,39 @@ export function ConditionGlyph({
   label,
   color,
   posteriorPct,
-  completenessPct,
-  confidence,
   badges = [],
 }: ConditionGlyphProps) {
-  const innerCirc = useMemo(() => 2 * Math.PI * 20, []); // r=20
-  const outerCirc = useMemo(() => 2 * Math.PI * 24, []); // r=24
-  const posteriorOffset = innerCirc * (1 - posteriorPct);
-  const completeOffset = outerCirc * (1 - completenessPct);
+  if (posteriorPct <= 0) return null;
+
+  const r = 24 * Math.sqrt(posteriorPct);
+  const cx = 28;
+  const cy = 28;
 
   return (
     <div className="condition-glyph" style={{ width: 72 }}>
       <svg width="56" height="56" viewBox="0 0 56 56">
         <circle
-          cx="28"
-          cy="28"
-          r="20"
-          stroke="#e5e7eb"
-          strokeWidth="8"
-          fill="none"
-        />
-        <circle
-          cx="28"
-          cy="28"
-          r="20"
-          stroke={color}
-          strokeWidth="8"
-          fill="none"
-          strokeDasharray={innerCirc}
-          strokeDashoffset={posteriorOffset}
-          style={{ transition: "stroke-dashoffset 0.5s" }}
-        />
-        <circle
-          cx="28"
-          cy="28"
-          r="24"
+          cx={cx}
+          cy={cy}
+          r={r}
+          fill={color}
+          opacity={0.3}
           stroke={color}
           strokeWidth="2"
-          fill="none"
-          strokeDasharray={outerCirc}
-          strokeDashoffset={completeOffset}
-          style={{ transition: "stroke-dashoffset 0.5s", opacity: 0.4 }}
         />
+        <text
+          x={cx}
+          y={cy}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="12"
+          fill="black"
+        >
+          {(posteriorPct * 100).toFixed(0)}%
+        </text>
       </svg>
       <div className="glyph-label" title={`${label} ${(posteriorPct * 100).toFixed(0)}%`}>
-        {label} {(posteriorPct * 100).toFixed(0)}%
+        {label}
       </div>
       {badges.length > 0 && (
         <div className="glyph-badges">
@@ -68,7 +54,6 @@ export function ConditionGlyph({
           ))}
         </div>
       )}
-      <div className="sr-only">{confidence} confidence</div>
     </div>
   );
 }

--- a/src/panels/SummaryPanel.tsx
+++ b/src/panels/SummaryPanel.tsx
@@ -127,8 +127,6 @@ export function SummaryPanel({
                 label={p.name}
                 color={colorMap[p.name]}
                 posteriorPct={p.name === "ASD" ? model.p : 0}
-                completenessPct={percent / 100}
-                confidence={confidence}
                 badges={[p.status]}
               />
             ))}


### PR DESCRIPTION
## Summary
- replace wheel glyph with circle whose radius reflects condition likelihood and percent shown inside
- simplify SummaryPanel to pass only needed props to ConditionGlyph

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a05931d1188325a6d598d7f2ded18d