### PR TITLE
feat: link ADOS-2 selections to condition summaries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
   FASD_NEURO_DOMAINS,
 } from "./data/testData";
 import type { Config, SeverityState, AssessmentSelection, ClientProfile, Condition } from "./types";
+import { ADOS2_CONDITION_WEIGHTS } from "./config/ados2ConditionWeights";
 
 import { Header, Footer } from "./components/ui";
 import { Container, Tabs, Card } from "./components/primitives";
@@ -343,6 +344,20 @@ export default function App() {
   const handleThresholdChange = (v: any) => {
     setConfig((c) => ({ ...c, certaintyThreshold: parseFloat(v) }));
   };
+
+  const conditionPercents = useMemo(() => {
+    const totals: Record<Condition, number> = { ASD: 0, ADHD: 0, FASD: 0, ID: 0 };
+    (Object.keys(totals) as Condition[]).forEach((cond) => {
+      let sum = 0;
+      Object.entries(ados).forEach(([domain, { severity }]) => {
+        if (!severity) return;
+        const weight = ADOS2_CONDITION_WEIGHTS[cond][domain]?.[severity as "Non-spectrum" | "Autism"];
+        if (typeof weight === "number") sum += weight;
+      });
+      totals[cond] = sum;
+    });
+    return totals;
+  }, [ados]);
 
   // ---------- rule signature ----------
   const ruleHash = useMemo(() => {
@@ -703,6 +718,7 @@ export default function App() {
                   history={history}
                   pathwayCandidates={pathwayCandidates}
                   evidence={evidence}
+                  conditionPercents={conditionPercents}
                 />
               </section>
             </div>

--- a/src/config/ados2ConditionWeights.ts
+++ b/src/config/ados2ConditionWeights.ts
@@ -1,0 +1,20 @@
+import type { Condition } from "../types";
+
+export const ADOS2_CONDITION_WEIGHTS: Record<Condition, Record<string, Record<string, number>>> = {
+  ASD: {
+    ados_social: { "Non-spectrum": -10, Autism: 20 },
+    ados_rrb: { "Non-spectrum": 10, Autism: 15 },
+  },
+  FASD: {
+    ados_social: { "Non-spectrum": 0, Autism: 5 },
+    ados_rrb: { "Non-spectrum": 0, Autism: 4 },
+  },
+  ADHD: {
+    ados_social: { "Non-spectrum": 0, Autism: 10 },
+    ados_rrb: { "Non-spectrum": 0, Autism: 20 },
+  },
+  ID: {
+    ados_social: { "Non-spectrum": 0, Autism: 0 },
+    ados_rrb: { "Non-spectrum": 0, Autism: 0 },
+  },
+};

--- a/src/data/testData.ts
+++ b/src/data/testData.ts
@@ -52,7 +52,7 @@ export const ASRS_DOMAINS: DomainLabelConfig[] = [
 // Generic severities for instruments without published bands
 export const GENERIC_SEVERITIES = ["Average", "Mild", "Moderate", "Severe"] as const;
 
-export const ADOS2_SEVERITIES = ["Minimal", "Low", "Moderate", "High"] as const;
+export const ADOS2_SEVERITIES = ["Non-spectrum", "Autism"] as const;
 export const MIGDAS_SEVERITIES = [
   "Not consistent",
   "Partially consistent",

--- a/src/panels/SummaryPanel.tsx
+++ b/src/panels/SummaryPanel.tsx
@@ -20,6 +20,7 @@ export function SummaryPanel({
   history,
   pathwayCandidates,
   evidence,
+  conditionPercents,
 }:{
   model: any;
   config: any;
@@ -34,6 +35,7 @@ export function SummaryPanel({
   history: { maskingIndicators: boolean; verbalFluency: string };
   pathwayCandidates: Record<Condition, boolean>;
   evidence: Record<string, number>;
+  conditionPercents: Record<Condition, number>;
 }) {
   const handleExport = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const v = e.target.value;
@@ -121,16 +123,16 @@ export function SummaryPanel({
       <Card title="Summary">
         <Stack>
           <div className="row">
-            {included.map((p) => (
-              <ConditionGlyph
-                key={p.name}
-                label={p.name}
-                color={colorMap[p.name]}
-                posteriorPct={p.name === "ASD" ? model.p : 0}
-                badges={[p.status]}
-              />
-            ))}
-          </div>
+          {included.map((p) => (
+            <ConditionGlyph
+              key={p.name}
+              label={p.name}
+              color={colorMap[p.name]}
+              posteriorPct={Math.max(0, conditionPercents[p.name]) / 100}
+              badges={[p.status]}
+            />
+          ))}
+        </div>
           <div className="chip-row" role="group" aria-label="Pathways">
             {pathways.map((p) => (
               <button


### PR DESCRIPTION
## Summary
- update ADOS-2 severity options to "Non-spectrum" and "Autism"
- map ADOS-2 Social Affect and RRB outcomes to condition-specific percentage weights
- show ADOS-2 derived condition percentages in the summary panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a062db5fb08325b676c2af62d572c7