### PR TITLE
Add SRS-2 condition weighting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import {
 import type { Config, SeverityState, AssessmentSelection, ClientProfile, Condition } from "./types";
 import { ADOS2_CONDITION_WEIGHTS } from "./config/ados2ConditionWeights";
 import { ADIR_CONDITION_WEIGHTS } from "./config/adirConditionWeights";
+import { SRS2_CONDITION_WEIGHTS } from "./config/srs2ConditionWeights";
 
 import { Header, Footer } from "./components/ui";
 import { Container, Tabs, Card } from "./components/primitives";
@@ -362,10 +363,24 @@ export default function App() {
         ];
         if (typeof weight === "number") sum += weight;
       });
+      Object.entries(srs2).forEach(([domain, { severity }]) => {
+        if (!severity) return;
+        const weight = SRS2_CONDITION_WEIGHTS[cond][domain]?.[
+          severity as "Average" | "Mild" | "Moderate" | "Severe"
+        ];
+        if (typeof weight === "number") sum += weight;
+      });
+      Object.entries(srs2Teacher).forEach(([domain, { severity }]) => {
+        if (!severity) return;
+        const weight = SRS2_CONDITION_WEIGHTS[cond][domain]?.[
+          severity as "Average" | "Mild" | "Moderate" | "Severe"
+        ];
+        if (typeof weight === "number") sum += weight;
+      });
       totals[cond] = sum;
     });
     return totals;
-  }, [ados, adir]);
+  }, [ados, adir, srs2, srs2Teacher]);
 
   // ---------- rule signature ----------
   const ruleHash = useMemo(() => {

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -94,27 +94,27 @@ export const DEFAULT_CONFIG: Config = {
   srs2Domains: SRS2_DOMAINS.map((d) => {
     const m: Record<string, InstrumentBandMap> = {};
     if (d.key === "srs_awareness") {
-      m["Within Normal Limits"] = { A1: -0.20 };
+      m["Average"] = { A1: -0.20 };
       m.Mild = { A1: -0.05 };
       m.Moderate = { A1: 0.60 };
       m.Severe = { A1: 1.10 };
     } else if (d.key === "srs_cognition") {
-      m["Within Normal Limits"] = { A2: -0.20 };
+      m["Average"] = { A2: -0.20 };
       m.Mild = { A2: -0.05 };
       m.Moderate = { A2: 0.60 };
       m.Severe = { A2: 1.10 };
     } else if (d.key === "srs_communication") {
-      m["Within Normal Limits"] = { A3: -0.20 };
+      m["Average"] = { A3: -0.20 };
       m.Mild = { A3: -0.05 };
       m.Moderate = { A3: 0.60 };
       m.Severe = { A3: 1.10 };
     } else if (d.key === "srs_motivation") {
-      m["Within Normal Limits"] = { A1: -0.05, A3: -0.05 };
+      m["Average"] = { A1: -0.05, A3: -0.05 };
       m.Mild = { A1: -0.02, A3: -0.02 };
       m.Moderate = { A1: 0.25, A3: 0.25 };
       m.Severe = { A1: 0.50, A3: 0.50 };
     } else if (d.key === "srs_rrb") {
-      m["Within Normal Limits"] = { B2: -0.15, B3: -0.15 };
+      m["Average"] = { B2: -0.15, B3: -0.15 };
       m.Mild = { B2: -0.05, B3: -0.05 };
       m.Moderate = { B2: 0.50, B3: 0.50 };
       m.Severe = { B2: 0.90, B3: 0.90 };

--- a/src/config/srs2ConditionWeights.ts
+++ b/src/config/srs2ConditionWeights.ts
@@ -1,0 +1,32 @@
+import type { Condition } from "../types";
+
+export const SRS2_CONDITION_WEIGHTS: Record<Condition, Record<string, Record<string, number>>> = {
+  ASD: {
+    srs_awareness: { Average: 0, Mild: 1, Moderate: 2, Severe: 3 },
+    srs_cognition: { Average: 0, Mild: 1, Moderate: 2, Severe: 3 },
+    srs_communication: { Average: 0, Mild: 1, Moderate: 2, Severe: 3 },
+    srs_motivation: { Average: 0, Mild: 1, Moderate: 2, Severe: 3 },
+    srs_rrb: { Average: 0, Mild: 1, Moderate: 2, Severe: 3 },
+  },
+  FASD: {
+    srs_awareness: { Average: -1, Mild: 1, Moderate: 2, Severe: 3 },
+    srs_cognition: { Average: -1, Mild: 1, Moderate: 2, Severe: 3 },
+    srs_communication: { Average: -1, Mild: 1, Moderate: 2, Severe: 3 },
+    srs_motivation: { Average: -1, Mild: 1, Moderate: 2, Severe: 3 },
+    srs_rrb: { Average: -1, Mild: 0, Moderate: 1, Severe: 3 },
+  },
+  ADHD: {
+    srs_awareness: { Average: 0, Mild: 0, Moderate: 1, Severe: 2 },
+    srs_cognition: { Average: 0, Mild: 1, Moderate: 2, Severe: 3 },
+    srs_communication: { Average: 0, Mild: 1, Moderate: 2, Severe: 3 },
+    srs_motivation: { Average: 0, Mild: 0, Moderate: 0, Severe: 0 },
+    srs_rrb: { Average: 0, Mild: 1, Moderate: 2, Severe: 3 },
+  },
+  ID: {
+    srs_awareness: { Average: 0, Mild: 0, Moderate: 0, Severe: 0 },
+    srs_cognition: { Average: 0, Mild: 0, Moderate: 0, Severe: 0 },
+    srs_communication: { Average: 0, Mild: 0, Moderate: 0, Severe: 0 },
+    srs_motivation: { Average: 0, Mild: 0, Moderate: 0, Severe: 0 },
+    srs_rrb: { Average: 0, Mild: 0, Moderate: 0, Severe: 0 },
+  },
+};

--- a/src/data/testData.ts
+++ b/src/data/testData.ts
@@ -23,7 +23,7 @@ export interface DomainLabelConfig {
 
 // ----------------------------- Autism Questionnaires -----------------------------
 export const SRS2_SEVERITIES = [
-  "Within Normal Limits",
+  "Average",
   "Mild",
   "Moderate",
   "Severe",


### PR DESCRIPTION
## Summary
- rename SRS-2 baseline band to "Average" and update domain evidence mapping
- introduce SRS-2 condition weights for ASD, FASD, ADHD, and ID
- include SRS-2 domain scores when computing condition confidence percentages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0664509a48325ba94165fb948a087