### PR TITLE
Implement threshold-based test weight highlighting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,8 +166,10 @@ export default function App() {
       Object.entries(domains).forEach(([domain, sevMap]) => {
         if (!result[domain]) result[domain] = {};
         Object.entries(sevMap).forEach(([sev, wt]) => {
-          const abs = Math.abs(wt);
-          result[domain][sev] = Math.max(result[domain][sev] || 0, abs);
+          const current = result[domain][sev];
+          if (current === undefined || Math.abs(wt) > Math.abs(current)) {
+            result[domain][sev] = wt;
+          }
         });
       });
     });

--- a/src/panels/AbasPanel.tsx
+++ b/src/panels/AbasPanel.tsx
@@ -22,7 +22,13 @@ export function AbasPanel({
       <div className="grid grid--sm">
         {domains.map(d=>{
           const sel = valueMap[d.key]?.severity || "";
-          const danger = highlightMap && Math.abs(highlightMap[d.key]?.[sel] || 0) >= 3;
+          const wt = highlightMap?.[d.key]?.[sel] ?? 0;
+          const tone =
+            wt >= 5
+              ? "tone-warn"
+              : wt >= 3 || wt <= -5
+              ? "tone-danger"
+              : undefined;
           return (
             <section key={d.key} className="card">
               <div className="stack stack--sm">
@@ -30,7 +36,7 @@ export function AbasPanel({
                   <div className="card-title" title={d.label}>{d.label}</div>
                   <select
                     value={sel}
-                    className={danger ? "tone-danger" : undefined}
+                    className={tone}
                     onChange={(e)=>setValueMap(s=>({ ...s, [d.key]: { ...s[d.key], severity: e.target.value }}))}
                   >
                     <option value="">Select</option>

--- a/src/panels/AsrsPanel.tsx
+++ b/src/panels/AsrsPanel.tsx
@@ -20,7 +20,13 @@ export function AsrsPanel({
       <div className="grid grid--sm">
         {domains.map(d=>{
           const sel = asrs[d.key]?.severity || "";
-          const danger = highlightMap && Math.abs(highlightMap[d.key]?.[sel] || 0) >= 3;
+          const wt = highlightMap?.[d.key]?.[sel] ?? 0;
+          const tone =
+            wt >= 5
+              ? "tone-warn"
+              : wt >= 3 || wt <= -5
+              ? "tone-danger"
+              : undefined;
           return (
             <section key={d.key} className="card">
               <div className="stack stack--sm">
@@ -28,7 +34,7 @@ export function AsrsPanel({
                   <div className="card-title" title={d.label}>{d.label}</div>
                   <select
                     value={sel}
-                    className={danger ? "tone-danger" : undefined}
+                    className={tone}
                     onChange={(e)=>setASRS(s=>({ ...s, [d.key]: { ...s[d.key], severity: e.target.value }}))}
                   >
                     <option value="">Select</option>

--- a/src/panels/DomainPanel.tsx
+++ b/src/panels/DomainPanel.tsx
@@ -18,36 +18,42 @@ export function DomainPanel({
   return (
     <Card title={title}>
       <div className="grid grid--sm">
-        {domains.map((d) => (
-          <section key={d.key} className="card">
-            <div className="stack stack--sm">
+        {domains.map((d) => {
+          const sel = valueMap[d.key]?.severity || "";
+          const wt = highlightMap?.[d.key]?.[sel] ?? 0;
+          const tone =
+            wt >= 5
+              ? "tone-warn"
+              : wt >= 3 || wt <= -5
+              ? "tone-danger"
+              : undefined;
+          return (
+            <section key={d.key} className="card">
+              <div className="stack stack--sm">
                 <label title={d.label}>
                   <div className="card-title" title={d.label}>{d.label}</div>
-                <select
-                  value={valueMap[d.key]?.severity || ""}
-                  className={
-                    highlightMap && Math.abs(highlightMap[d.key]?.[valueMap[d.key]?.severity || ""] || 0) >= 3
-                      ? "tone-danger"
-                      : undefined
-                  }
-                  onChange={(e) =>
-                    setValueMap((s) => ({
-                      ...s,
-                      [d.key]: { ...s[d.key], severity: e.target.value },
-                    }))
-                  }
-                >
-                  <option value="">Select</option>
-                  {d.severities.map((sev) => (
-                    <option key={sev} value={sev}>
-                      {sev}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            </div>
-          </section>
-        ))}
+                  <select
+                    value={sel}
+                    className={tone}
+                    onChange={(e) =>
+                      setValueMap((s) => ({
+                        ...s,
+                        [d.key]: { ...s[d.key], severity: e.target.value },
+                      }))
+                    }
+                  >
+                    <option value="">Select</option>
+                    {d.severities.map((sev) => (
+                      <option key={sev} value={sev}>
+                        {sev}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+            </section>
+          );
+        })}
       </div>
     </Card>
   );

--- a/src/panels/SrsPanel.tsx
+++ b/src/panels/SrsPanel.tsx
@@ -20,8 +20,13 @@ export function SrsPanel({
       <div className="grid grid--sm">
         {domains.map((d) => {
           const sel = srs2[d.key]?.severity || "";
-          const danger =
-            highlightMap && Math.abs(highlightMap[d.key]?.[sel] || 0) >= 3;
+          const wt = highlightMap?.[d.key]?.[sel] ?? 0;
+          const tone =
+            wt >= 5
+              ? "tone-warn"
+              : wt >= 3 || wt <= -5
+              ? "tone-danger"
+              : "";
           return (
             <section key={d.key} className="card">
               <div className="stack stack--sm">
@@ -29,7 +34,7 @@ export function SrsPanel({
                 <label>
                   <select
                     value={sel}
-                    className={(sel ? "" : "invalid") + (danger ? " tone-danger" : "")}
+                    className={(sel ? "" : "invalid") + (tone ? ` ${tone}` : "")}
                     title={sel ? "" : "Select severity"}
                     onChange={(e) =>
                       setSRS2((s) => ({

--- a/src/panels/VinelandPanel.tsx
+++ b/src/panels/VinelandPanel.tsx
@@ -23,9 +23,15 @@ export function VinelandPanel({
       <div className="grid grid--sm">
         {domains.map(d=>{
           const sel = valueMap[d.key] || "";
-          const danger = highlightMap && Math.abs(highlightMap[d.key]?.[sel] || 0) >= 3;
+          const wt = highlightMap?.[d.key]?.[sel] ?? 0;
+          const tone =
+            wt >= 5
+              ? "tone-warn"
+              : wt >= 3 || wt <= -5
+              ? "tone-danger"
+              : "";
           return (
-            <section key={d.key} className={"card" + (danger ? " tone-danger" : "") }>
+            <section key={d.key} className={"card" + (tone ? ` ${tone}` : "") }>
               <div className="stack stack--sm">
                 <div className="row row--between row--center">
                   <div className="card-title" title={d.label}>{d.label}</div>


### PR DESCRIPTION
## Summary
- keep sign when building highlight map for condition weights
- color dropdowns: positive 3–4 red, ≥5 yellow; negative ≤ -5 red
- apply new weight thresholds across all domain panels

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a06d4e2abc832590a73d02ea2da5f9