### PR TITLE
Add BRIEF-2 parent/teacher scoring with condition weights

### DIFF
--- a/src/config/brief2ConditionWeights.ts
+++ b/src/config/brief2ConditionWeights.ts
@@ -1,0 +1,48 @@
+import type { Condition } from "../types";
+
+export const BRIEF2_CONDITION_WEIGHTS: Record<Condition, Record<string, Record<string, number>>> = {
+  ASD: {
+    brief_inhibition: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_self_monitor: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_shift: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_emotional: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_initiate: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_working_memory: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_plan_organize: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_task_monitor: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_materials: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+  },
+  FASD: {
+    brief_inhibition: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_self_monitor: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_shift: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_emotional: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_initiate: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_working_memory: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_plan_organize: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_task_monitor: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_materials: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+  },
+  ADHD: {
+    brief_inhibition: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_self_monitor: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_shift: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_emotional: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_initiate: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_working_memory: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_plan_organize: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_task_monitor: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_materials: { Average: 0, "Mildly Elevated": 1, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+  },
+  ID: {
+    brief_inhibition: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_self_monitor: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_shift: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_emotional: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_initiate: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_working_memory: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_plan_organize: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_task_monitor: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+    brief_materials: { Average: 0, "Mildly Elevated": 0, "Potentially Clinically Elevated": 1, "Clinically Elevated": 1 },
+  },
+};

--- a/src/data/testData.ts
+++ b/src/data/testData.ts
@@ -65,7 +65,12 @@ export const ADIR_SEVERITIES = [
 ] as const;
 export const AQ_SEVERITIES = ["Below threshold", "At-or-above threshold"] as const;
 export const CELF5_SEVERITIES = ["Very Low", "Low", "Below Average", "Average", "Above Average"] as const;
-export const BRIEF2_SEVERITIES = ["Within Normal Limits", "Elevated", "Very Elevated"] as const;
+export const BRIEF2_SEVERITIES = [
+  "Average",
+  "Mildly Elevated",
+  "Potentially Clinically Elevated",
+  "Clinically Elevated",
+] as const;
 export const BDEFS_SEVERITIES = ["Average", "Moderately Deficient", "Severe"] as const;
 export const CONNERS_SEVERITIES = ["Average", "Elevated", "Very Elevated"] as const;
 export const VANDERBILT_SEVERITIES = ["No", "Yes"] as const;


### PR DESCRIPTION
## Summary
- expand BRIEF-2 severity bands to full clinical ranges
- add condition weight mappings for BRIEF-2 domains
- support parent & teacher BRIEF-2 panels for ages 5–18 and wire into summary condition percentages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a06f0207cc83259f25018f6216fb7a