### PR TITLE
Fix BRIEF-2 front-page display and add Sensory Profile weights

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { ADIR_CONDITION_WEIGHTS } from "./config/adirConditionWeights";
 import { SRS2_CONDITION_WEIGHTS } from "./config/srs2ConditionWeights";
 import { VINELAND_CONDITION_WEIGHTS } from "./config/vinelandConditionWeights";
 import { BRIEF2_CONDITION_WEIGHTS } from "./config/brief2ConditionWeights";
+import { SENSORY_PROFILE_CONDITION_WEIGHTS } from "./config/sensoryProfileConditionWeights";
 
 import { Header, Footer } from "./components/ui";
 import { Container, Tabs, Card } from "./components/primitives";
@@ -183,6 +184,10 @@ export default function App() {
   const srsHighlight = useMemo(() => buildHighlightMap(SRS2_CONDITION_WEIGHTS), []);
   const vinelandHighlight = useMemo(() => buildHighlightMap(VINELAND_CONDITION_WEIGHTS), []);
   const briefHighlight = useMemo(() => buildHighlightMap(BRIEF2_CONDITION_WEIGHTS), []);
+  const sensoryHighlight = useMemo(
+    () => buildHighlightMap(SENSORY_PROFILE_CONDITION_WEIGHTS),
+    [],
+  );
 
   // ---------- assessment selections ----------
   const [assessments, setAssessments] = useState<AssessmentSelection[]>([
@@ -443,10 +448,22 @@ export default function App() {
         ];
         if (typeof weight === "number") sum += weight;
       });
+      Object.entries(sensory).forEach(([domain, { severity }]) => {
+        if (!severity) return;
+        const weight = SENSORY_PROFILE_CONDITION_WEIGHTS[cond][domain]?.[
+          severity as
+            | "Much Less Than Others"
+            | "Less Than Others"
+            | "Just Like the Majority"
+            | "More Than Others"
+            | "Much More Than Others"
+        ];
+        if (typeof weight === "number") sum += weight;
+      });
       totals[cond] = sum;
     });
     return totals;
-  }, [ados, adir, srs2, srs2Teacher, vineland, briefParent, briefTeacher]);
+  }, [ados, adir, srs2, srs2Teacher, vineland, briefParent, briefTeacher, sensory]);
 
   // ---------- rule signature ----------
   const ruleHash = useMemo(() => {
@@ -761,6 +778,7 @@ export default function App() {
                       domains={SENSORY_PROFILE_DOMAINS}
                       valueMap={sensory}
                       setValueMap={setSensory}
+                      highlightMap={sensoryHighlight}
                     />
                   )}
                   {selectedSensory.filter((n) => n !== "Sensory Profile 2").length > 0 && (

--- a/src/config/sensoryProfileConditionWeights.ts
+++ b/src/config/sensoryProfileConditionWeights.ts
@@ -1,0 +1,157 @@
+import type { Condition } from "../types";
+
+type Severity =
+  | "Much Less Than Others"
+  | "Less Than Others"
+  | "Just Like the Majority"
+  | "More Than Others"
+  | "Much More Than Others";
+
+type Quadrant = "sensitivity" | "avoiding" | "seeking" | "registration";
+
+const senses = ["auditory", "visual", "tactile", "vestibular", "oral"] as const;
+
+const quadrantWeights: Record<Condition, Record<Quadrant, Record<Severity, number>>> = {
+  ASD: {
+    sensitivity: {
+      "Much Less Than Others": -0.5,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 0,
+      "Much More Than Others": 2,
+    },
+    avoiding: {
+      "Much Less Than Others": 0,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 0,
+      "Much More Than Others": 0,
+    },
+    seeking: {
+      "Much Less Than Others": 0,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 0,
+      "Much More Than Others": 2,
+    },
+    registration: {
+      "Much Less Than Others": 0,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 0,
+      "Much More Than Others": 0,
+    },
+  },
+  FASD: {
+    sensitivity: {
+      "Much Less Than Others": 0,
+      "Less Than Others": -1,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+    avoiding: {
+      "Much Less Than Others": 0,
+      "Less Than Others": -1,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+    seeking: {
+      "Much Less Than Others": 0,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+    registration: {
+      "Much Less Than Others": 0,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+  },
+  ADHD: {
+    sensitivity: {
+      "Much Less Than Others": -1,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+    avoiding: {
+      "Much Less Than Others": 0,
+      "Less Than Others": -1,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+    seeking: {
+      "Much Less Than Others": -1,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+    registration: {
+      "Much Less Than Others": 0,
+      "Less Than Others": -1,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+  },
+  ID: {
+    sensitivity: {
+      "Much Less Than Others": 0,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+    avoiding: {
+      "Much Less Than Others": 0,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+    seeking: {
+      "Much Less Than Others": 0,
+      "Less Than Others": 0,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+    registration: {
+      "Much Less Than Others": 0,
+      "Less Than Others": -1,
+      "Just Like the Majority": 0,
+      "More Than Others": 1,
+      "Much More Than Others": 0,
+    },
+  },
+};
+
+export const SENSORY_PROFILE_CONDITION_WEIGHTS: Record<Condition, Record<string, Record<Severity, number>>> = (() => {
+  const result: Record<Condition, Record<string, Record<Severity, number>>> = {
+    ASD: {},
+    FASD: {},
+    ADHD: {},
+    ID: {},
+  };
+  (Object.keys(result) as Condition[]).forEach((cond) => {
+    senses.forEach((sense) => {
+      const prefix = `sensory_${sense}_`;
+      result[cond][`${prefix}sensitivity`] = quadrantWeights[cond].sensitivity;
+      result[cond][`${prefix}avoiding`] = quadrantWeights[cond].avoiding;
+      result[cond][`${prefix}seeking`] = quadrantWeights[cond].seeking;
+      result[cond][`${prefix}registration`] = quadrantWeights[cond].registration;
+    });
+  });
+  return result;
+})();
+
+default export SENSORY_PROFILE_CONDITION_WEIGHTS;
+

--- a/src/panels/ReportPanel.tsx
+++ b/src/panels/ReportPanel.tsx
@@ -3,6 +3,19 @@ import type { SeverityState, Config, AssessmentSelection, ClientProfile } from "
 import { Card } from "../components/primitives";
 import { ASSESSMENT_INFO } from "../data/assessmentInfo";
 
+const NAME_MAP: Record<string, string> = {
+  ABAS3: "ABAS-3",
+  Vineland: "Vineland-3",
+  MIGDAS: "MIGDAS-2",
+  ADOS: "ADOS-2",
+  BRIEF2: "BRIEF-2",
+  WISC: "WISC/WAIS/WPPSI",
+  WPPSI: "WISC/WAIS/WPPSI",
+  WAIS: "WISC/WAIS/WPPSI",
+  "Sensory profile 2": "Sensory Profile 2",
+  CELF5: "CELF-5",
+};
+
 export function ReportPanel({
   model,
   supportEstimate,
@@ -80,14 +93,15 @@ export function ReportPanel({
       lines.push(`${ASSESSMENT_INFO.migdas2.name}: Consistency ${migdas.consistency}`);
 
     instruments.forEach((i) => {
-      if (i.name === "Vineland-3" && (abasParent || abasTeach)) return;
-      if (i.name === "ASRS" && (asrsParent || asrsTeach)) return;
+      const name = NAME_MAP[i.name] || i.name;
+      if (name === "Vineland-3" && (abasParent || abasTeach)) return;
+      if (name === "ASRS" && (asrsParent || asrsTeach)) return;
       if (i.value !== undefined || (i.band && i.band.trim() !== ""))
-        lines.push(`${i.name}: ${i.value !== undefined ? i.value : i.band}`);
+        lines.push(`${name}: ${i.value !== undefined ? i.value : i.band}`);
     });
 
     assessments.forEach((a) => {
-      if (a.selected) lines.push(a.selected);
+      if (a.selected) lines.push(NAME_MAP[a.selected] || a.selected);
     });
 
     const testList = lines.map((l) => l.split(":")[0]).join(", ");


### PR DESCRIPTION
## Summary
- Map internal assessment codes to display names so BRIEF-2 and other tests appear on the report front page
- Introduce Sensory Profile 2 condition weight matrix and integrate into condition confidence calculations
- Highlight Sensory Profile results in the UI using new weight mappings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0720249e0832585352a54f4952ce7