### PR TITLE
feat: add ASRS condition weights and fix export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,10 @@ import { SRS2_CONDITION_WEIGHTS } from "./config/srs2ConditionWeights";
 import { VINELAND_CONDITION_WEIGHTS } from "./config/vinelandConditionWeights";
 import { BRIEF2_CONDITION_WEIGHTS } from "./config/brief2ConditionWeights";
 import { SENSORY_PROFILE_CONDITION_WEIGHTS } from "./config/sensoryProfileConditionWeights";
+import {
+  ASRS_CONDITION_WEIGHTS_2_5,
+  ASRS_CONDITION_WEIGHTS_6_18,
+} from "./config/asrsConditionWeights";
 
 import { Header, Footer } from "./components/ui";
 import { Container, Tabs, Card } from "./components/primitives";
@@ -318,6 +322,9 @@ export default function App() {
   }, [age]);
 
   const isSchoolAge = age < 18;
+
+  const asrsWeights = age < 6 ? ASRS_CONDITION_WEIGHTS_2_5 : ASRS_CONDITION_WEIGHTS_6_18;
+  const asrsHighlight = useMemo(() => buildHighlightMap(asrsWeights), [asrsWeights]);
   const isBriefAge = age >= 5 && age <= 18;
 
   useEffect(() => {
@@ -419,6 +426,28 @@ export default function App() {
         ];
         if (typeof weight === "number") sum += weight;
       });
+      Object.entries(asrs).forEach(([domain, { severity }]) => {
+        if (!severity) return;
+        const weight = asrsWeights[cond][domain]?.[
+          severity as
+            | "Average"
+            | "Slightly Elevated"
+            | "Elevated"
+            | "Very Elevated"
+        ];
+        if (typeof weight === "number") sum += weight;
+      });
+      Object.entries(asrsTeacher).forEach(([domain, { severity }]) => {
+        if (!severity) return;
+        const weight = asrsWeights[cond][domain]?.[
+          severity as
+            | "Average"
+            | "Slightly Elevated"
+            | "Elevated"
+            | "Very Elevated"
+        ];
+        if (typeof weight === "number") sum += weight;
+      });
       Object.entries(vineland).forEach(([domain, { severity }]) => {
         if (!severity) return;
         const weight = VINELAND_CONDITION_WEIGHTS[cond][domain]?.[
@@ -463,7 +492,7 @@ export default function App() {
       totals[cond] = sum;
     });
     return totals;
-  }, [ados, adir, srs2, srs2Teacher, vineland, briefParent, briefTeacher, sensory]);
+  }, [ados, adir, srs2, srs2Teacher, asrs, asrsTeacher, vineland, briefParent, briefTeacher, sensory, asrsWeights]);
 
   // ---------- rule signature ----------
   const ruleHash = useMemo(() => {
@@ -613,13 +642,20 @@ export default function App() {
               )}
               {hasAsrs && (
                 <>
-                  <AsrsPanel title="ASRS Parent" domains={config.asrsDomains} asrs={asrs} setASRS={setASRS} />
+                  <AsrsPanel
+                    title="ASRS Parent"
+                    domains={config.asrsDomains}
+                    asrs={asrs}
+                    setASRS={setASRS}
+                    highlightMap={asrsHighlight}
+                  />
                   {isSchoolAge && (
                     <AsrsPanel
                       title="ASRS Teacher"
                       domains={config.asrsDomains}
                       asrs={asrsTeacher}
                       setASRS={setASRSTeacher}
+                      highlightMap={asrsHighlight}
                     />
                   )}
                 </>

--- a/src/config/asrsConditionWeights.ts
+++ b/src/config/asrsConditionWeights.ts
@@ -1,0 +1,47 @@
+import type { Condition } from "../types";
+
+export const ASRS_CONDITION_WEIGHTS_2_5: Record<Condition, Record<string, Record<string, number>>> = {
+  ASD: {
+    asrs_social_communication: { Average: 0, "Slightly Elevated": 1, Elevated: 2, "Very Elevated": 3 },
+    asrs_unusual_behaviours: { Average: 0, "Slightly Elevated": 1, Elevated: 2, "Very Elevated": 3 },
+    asrs_self_regulation: { Average: 0, "Slightly Elevated": 0, Elevated: 1, "Very Elevated": 2 },
+  },
+  FASD: {
+    asrs_social_communication: { Average: -1, "Slightly Elevated": 0, Elevated: 1, "Very Elevated": 0 },
+    asrs_unusual_behaviours: { Average: -1, "Slightly Elevated": 0, Elevated: 1, "Very Elevated": 2 },
+    asrs_self_regulation: { Average: 0, "Slightly Elevated": 0, Elevated: 1, "Very Elevated": 2 },
+  },
+  ADHD: {
+    asrs_social_communication: { Average: 0, "Slightly Elevated": 0, Elevated: 1, "Very Elevated": 2 },
+    asrs_unusual_behaviours: { Average: 0, "Slightly Elevated": 1, Elevated: 1, "Very Elevated": 1 },
+    asrs_self_regulation: { Average: 0, "Slightly Elevated": 1, Elevated: 1, "Very Elevated": 1 },
+  },
+  ID: {
+    asrs_social_communication: { Average: 0, "Slightly Elevated": 0, Elevated: 1, "Very Elevated": 1 },
+    asrs_unusual_behaviours: { Average: 0, "Slightly Elevated": 0, Elevated: 0, "Very Elevated": 1 },
+    asrs_self_regulation: { Average: 0, "Slightly Elevated": 0, Elevated: 0, "Very Elevated": 1 },
+  },
+};
+
+export const ASRS_CONDITION_WEIGHTS_6_18: Record<Condition, Record<string, Record<string, number>>> = {
+  ASD: {
+    asrs_social_communication: { Average: 0, "Slightly Elevated": 1, Elevated: 2, "Very Elevated": 3 },
+    asrs_unusual_behaviours: { Average: 0, "Slightly Elevated": 0, Elevated: 1, "Very Elevated": 2 },
+    asrs_self_regulation: { Average: 0, "Slightly Elevated": 0, Elevated: 0, "Very Elevated": 0 },
+  },
+  FASD: {
+    asrs_social_communication: { Average: -1, "Slightly Elevated": 0, Elevated: 1, "Very Elevated": 0 },
+    asrs_unusual_behaviours: { Average: -1, "Slightly Elevated": 0, Elevated: 1, "Very Elevated": 1 },
+    asrs_self_regulation: { Average: 0, "Slightly Elevated": 0, Elevated: 0, "Very Elevated": 1 },
+  },
+  ADHD: {
+    asrs_social_communication: { Average: 0, "Slightly Elevated": 0, Elevated: 1, "Very Elevated": 1 },
+    asrs_unusual_behaviours: { Average: 0, "Slightly Elevated": 1, Elevated: 1, "Very Elevated": 1 },
+    asrs_self_regulation: { Average: 0, "Slightly Elevated": 1, Elevated: 1, "Very Elevated": 1 },
+  },
+  ID: {
+    asrs_social_communication: { Average: 0, "Slightly Elevated": 0, Elevated: 0, "Very Elevated": 1 },
+    asrs_unusual_behaviours: { Average: 0, "Slightly Elevated": 0, Elevated: 0, "Very Elevated": 1 },
+    asrs_self_regulation: { Average: 0, "Slightly Elevated": 0, Elevated: 0, "Very Elevated": 1 },
+  },
+};

--- a/src/config/sensoryProfileConditionWeights.ts
+++ b/src/config/sensoryProfileConditionWeights.ts
@@ -153,5 +153,5 @@ export const SENSORY_PROFILE_CONDITION_WEIGHTS: Record<Condition, Record<string,
   return result;
 })();
 
-default export SENSORY_PROFILE_CONDITION_WEIGHTS;
+export default SENSORY_PROFILE_CONDITION_WEIGHTS;
 

--- a/src/data/testData.ts
+++ b/src/data/testData.ts
@@ -39,6 +39,7 @@ export const SRS2_DOMAINS: DomainLabelConfig[] = [
 
 export const ASRS_SEVERITIES = [
   "Average",
+  "Slightly Elevated",
   "Elevated",
   "Very Elevated",
 ] as const;


### PR DESCRIPTION
## Summary
- add age-specific ASRS (2-5 and 6-18) condition weight tables
- include ASRS in condition percentage calculations and UI highlights
- fix sensory profile condition weight export

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0750906808325b1605992d740bdee