### PR TITLE
Add BRIEF-2 (v2) instrument variant

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -252,6 +252,7 @@ export default function App() {
       domain: "Executive function questionnaires",
       options: [
         "BRIEF-2",
+        "BRIEF-2 (v2)",
         "BDEFS",
         "Conners-4",
         "Conners-EC",
@@ -285,6 +286,7 @@ export default function App() {
     MIGDAS: "MIGDAS-2",
     ADOS: "ADOS-2",
     "BRIEF-2": "BRIEF-2",
+    "BRIEF-2 (v2)": "BRIEF-2 (v2)",
     WISC: "WISC/WAIS/WPPSI",
     WPPSI: "WISC/WAIS/WPPSI",
     WAIS: "WISC/WAIS/WPPSI",
@@ -322,6 +324,7 @@ export default function App() {
   const selectedExecutive = getSelectedNames("Executive function questionnaires");
   const selectedSensory = getSelectedNames("Sensory Assessment");
   const selectedLanguage = getSelectedNames("Language assessment");
+  const briefName = selectedExecutive.find((n) => n.startsWith("BRIEF-2"));
 
   const pathwayCandidates = useMemo(() => {
     const asd = assessments.some((a) =>
@@ -329,7 +332,7 @@ export default function App() {
     );
     const adhd = assessments.some((a) => {
       const sel = a.selected || "";
-      return ["Conners-4", "Conners-EC", "Vanderbilt", "BRIEF-2", "BRIEF", "BDEFS"].some(
+      return ["Conners-4", "Conners-EC", "Vanderbilt", "BRIEF-2", "BRIEF-2 (v2)", "BRIEF", "BDEFS"].some(
         (k) => sel.toLowerCase().includes(k.toLowerCase()),
       );
     });
@@ -821,29 +824,33 @@ export default function App() {
 
               {selectedExecutive.length > 0 && (
                 <>
-                  {selectedExecutive.includes("BRIEF-2") && isBriefAge && (
-                    <>
-                      <DomainPanel
-                        title="BRIEF-2 Parent"
-                        domains={BRIEF2_DOMAINS}
-                        valueMap={briefParent}
-                        setValueMap={setBRIEFParent}
-                        highlightMap={briefHighlight}
-                      />
-                      {isSchoolAge && (
+                  {selectedExecutive.some((n) => n.startsWith("BRIEF-2")) &&
+                    isBriefAge && (
+                      <>
                         <DomainPanel
-                          title="BRIEF-2 Teacher"
+                          title={`${briefName} Parent`}
                           domains={BRIEF2_DOMAINS}
-                          valueMap={briefTeacher}
-                          setValueMap={setBRIEFTeacher}
+                          valueMap={briefParent}
+                          setValueMap={setBRIEFParent}
                           highlightMap={briefHighlight}
                         />
-                      )}
-                    </>
-                  )}
-                  {selectedExecutive.filter((n) => n !== "BRIEF-2").length > 0 && (
+                        {isSchoolAge && (
+                          <DomainPanel
+                            title={`${briefName} Teacher`}
+                            domains={BRIEF2_DOMAINS}
+                            valueMap={briefTeacher}
+                            setValueMap={setBRIEFTeacher}
+                            highlightMap={briefHighlight}
+                          />
+                        )}
+                      </>
+                    )}
+                  {selectedExecutive.filter((n) => !n.startsWith("BRIEF-2"))
+                    .length > 0 && (
                     <GenericInstrumentPanel
-                      selected={selectedExecutive.filter((n) => n !== "BRIEF-2")}
+                      selected={selectedExecutive.filter(
+                        (n) => !n.startsWith("BRIEF-2"),
+                      )}
                       instruments={instruments}
                       setInstruments={setInstruments}
                       configs={config.defaultInstruments}

--- a/src/components/QuickAddPresets.tsx
+++ b/src/components/QuickAddPresets.tsx
@@ -10,6 +10,7 @@ const INSTRUMENT_DOMAIN: Record<string, string> = {
   Vineland: "Adaptive questionnaires",
   ABAS3: "Adaptive questionnaires",
   "BRIEF-2": "Executive function questionnaires",
+  "BRIEF-2 (v2)": "Executive function questionnaires",
 };
 
 const PRESETS: Record<string, string[]> = {

--- a/src/config/asdWeights.ts
+++ b/src/config/asdWeights.ts
@@ -209,34 +209,69 @@ export const ASD_WEIGHTS_V1: ASDWeightConfig = {
             name: "Shift (cognitive flexibility)",
             direction: "high",
             delta_pct: { severe: 3, moderate: 2, typical: -2 },
-        },
-        {
-          name: "Working Memory",
-          direction: "high",
-          delta_pct: { severe: 1, moderate: 0.5, typical: -0.5 },
-        },
-        {
-          name: "Plan / Organize",
-          direction: "high",
-          delta_pct: { severe: 1, moderate: 1, typical: -0.5 },
-        },
-        {
-          name: "Initiate",
-          direction: "high",
-          delta_pct: { severe: 2, moderate: 1, typical: -1 },
-        },
-        {
-          name: "Self-Monitor / Task-Monitor",
-          direction: "high",
-          delta_pct: { severe: 1, moderate: 0.5, typical: -0.5 },
-        },
-        {
-          name: "Inhibit / Emotional Control / Organization of Materials",
-          direction: "high",
-          delta_pct: { severe: 0.5, moderate: 0.5, typical: -0.25 },
-        },
-      ],
-    },
+          },
+          {
+            name: "Working Memory",
+            direction: "high",
+            delta_pct: { severe: 1, moderate: 0.5, typical: -0.5 },
+          },
+          {
+            name: "Plan / Organize",
+            direction: "high",
+            delta_pct: { severe: 1, moderate: 1, typical: -0.5 },
+          },
+          {
+            name: "Initiate",
+            direction: "high",
+            delta_pct: { severe: 2, moderate: 1, typical: -1 },
+          },
+          {
+            name: "Self-Monitor / Task-Monitor",
+            direction: "high",
+            delta_pct: { severe: 1, moderate: 0.5, typical: -0.5 },
+          },
+          {
+            name: "Inhibit / Emotional Control / Organization of Materials",
+            direction: "high",
+            delta_pct: { severe: 0.5, moderate: 0.5, typical: -0.25 },
+          },
+        ],
+      },
+      "BRIEF-2 (v2)": {
+        cap_pct: 8.5,
+        subscales: [
+          {
+            name: "Shift (cognitive flexibility)",
+            direction: "high",
+            delta_pct: { severe: 3, moderate: 2, typical: -2 },
+          },
+          {
+            name: "Working Memory",
+            direction: "high",
+            delta_pct: { severe: 1, moderate: 0.5, typical: -0.5 },
+          },
+          {
+            name: "Plan / Organize",
+            direction: "high",
+            delta_pct: { severe: 1, moderate: 1, typical: -0.5 },
+          },
+          {
+            name: "Initiate",
+            direction: "high",
+            delta_pct: { severe: 2, moderate: 1, typical: -1 },
+          },
+          {
+            name: "Self-Monitor / Task-Monitor",
+            direction: "high",
+            delta_pct: { severe: 1, moderate: 0.5, typical: -0.5 },
+          },
+          {
+            name: "Inhibit / Emotional Control / Organization of Materials",
+            direction: "high",
+            delta_pct: { severe: 0.5, moderate: 0.5, typical: -0.25 },
+          },
+        ],
+      },
       BDEFS: {
         cap_pct: 6,
         subscales: [

--- a/src/config/modelConfig.ts
+++ b/src/config/modelConfig.ts
@@ -78,6 +78,7 @@ export const DEFAULT_CONFIG: Config = {
     { name: "ABAS-3", scoreField: "composite", thresholds: [] },
     { name: "WISC/WAIS/WPPSI", scoreField: "index", thresholds: [] },
     { name: "BRIEF-2", scoreField: "t", thresholds: [] },
+    { name: "BRIEF-2 (v2)", scoreField: "t", thresholds: [] },
     { name: "BDEFS", scoreField: "t", thresholds: [] },
     { name: "Sensory Profile 2", scoreField: "standard", thresholds: [] },
     { name: "CELF-5", scoreField: "index", thresholds: [] },

--- a/src/data/assessmentInfo.ts
+++ b/src/data/assessmentInfo.ts
@@ -104,6 +104,16 @@ export const ASSESSMENT_INFO: Record<string, AssessmentInfo> = {
     notes:
       "T-scores have mean = 50 (SD = 10) and yield a Global Executive Composite; scores \u226565 indicate clinical concern.",
   },
+  brief2v2: {
+    name: "BRIEF-2 (v2) (Behavior Rating Inventory of Executive Function, 2nd Edition)",
+    domains: [
+      "Behavioral Regulation Index",
+      "Emotional Regulation Index",
+      "Cognitive Regulation Index",
+    ],
+    notes:
+      "T-scores have mean = 50 (SD = 10) and yield a Global Executive Composite; scores \u226565 indicate clinical concern.",
+  },
   bdefs: {
     name: "BDEFS (Barkley Deficits in Executive Functioning Scale)",
     domains: [

--- a/src/panels/ReportPanel.tsx
+++ b/src/panels/ReportPanel.tsx
@@ -9,6 +9,7 @@ const NAME_MAP: Record<string, string> = {
   MIGDAS: "MIGDAS-2",
   ADOS: "ADOS-2",
   "BRIEF-2": "BRIEF-2",
+  "BRIEF-2 (v2)": "BRIEF-2 (v2)",
   WISC: "WISC/WAIS/WPPSI",
   WPPSI: "WISC/WAIS/WPPSI",
   WAIS: "WISC/WAIS/WPPSI",


### PR DESCRIPTION
## Summary
- Duplicate BRIEF-2 instrument as BRIEF-2 (v2) across config and weight tables
- Include BRIEF-2 (v2) in quick-add presets, assessment info, and report mappings
- Update app logic to render either BRIEF-2 variant with shared domain panels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a07eb052608325be5caa9009916360