### PR TITLE
Ensure ASRS highlights and expand report

### DIFF
--- a/src/panels/AsrsPanel.tsx
+++ b/src/panels/AsrsPanel.tsx
@@ -24,7 +24,7 @@ export function AsrsPanel({
           const tone =
             wt >= 5
               ? "tone-warn"
-              : wt >= 3 || wt <= -5
+              : sel === "Very Elevated" || wt >= 3 || wt <= -5
               ? "tone-danger"
               : undefined;
           return (

--- a/src/panels/ReportPanel.tsx
+++ b/src/panels/ReportPanel.tsx
@@ -131,12 +131,14 @@ export function ReportPanel({
       : "";
     const contextNote =
       " Clinical interpretation should consider developmental history and individual context.";
+    const recommendationText =
+      " Regular monitoring and periodic reassessment are recommended to track progress and adjust supports as needed.";
     const assessmentsText = lines.length
       ? `Assessments:\n${lines.map((l) => `- ${l}`).join("\n")}\n\n`
       : "";
     const intro = client.name || client.age ? `${client.name || "Client"}, Age ${client.age || "N/A"}\n\n` : "";
     const summary = testList
-      ? `${early}Multiple tests completed including ${testList} ${presence}. ${support}${impactText}.${difficultyText}${contextNote}`
+      ? `${early}Multiple tests completed including ${testList} ${presence}. ${support}${impactText}.${difficultyText}${contextNote}${recommendationText}`
       : "Insufficient data for report.";
     return `${intro}${assessmentsText}${summary}`;
   }, [

--- a/src/panels/SummaryPanel.tsx
+++ b/src/panels/SummaryPanel.tsx
@@ -157,7 +157,7 @@ export function SummaryPanel({
             ))}
           </div>
           <div>
-            <div style={{fontSize:32,fontWeight:800}}>{(model.p*100).toFixed(1)}%</div>
+            <div style={{fontSize:32,fontWeight:800}}>{(model.p*100).toFixed(1)}</div>
             <div className="small">Overall ASD likelihood</div>
             <label className="small row row--center" style={{gap:"var(--space-inset)"}} title="Threshold">
               <span>Threshold:</span>


### PR DESCRIPTION
## Summary
- Color all "Very Elevated" ASRS selections and use yellow for weights ≥5
- Remove obsolete percent sign from summary likelihood display
- Add recommendation sentence to report preview for more context

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a080b9884c8325bffb3adba3257d99