### PR TITLE
Fix assessment selector filter and client form inputs

### DIFF
--- a/src/components/AssessmentSelector.tsx
+++ b/src/components/AssessmentSelector.tsx
@@ -54,14 +54,18 @@ export function AssessmentSelector({
 
   const allOptions = useMemo(() => {
     const opts: { name: string; category: string; domain: string; eligible?: boolean }[] = [];
-    assessments.forEach((a) => {
-      const category = CATEGORY_MAP[a.domain];
-      a.options.forEach((opt) => {
-        if (category) {
-          opts.push({ name: opt, category, domain: a.domain, eligible: true });
-        }
+    // Only include base domain definitions (those without a selected instrument)
+    // so that adding an assessment doesn't duplicate options and break filtering.
+    assessments
+      .filter((a) => !a.selected)
+      .forEach((a) => {
+        const category = CATEGORY_MAP[a.domain];
+        a.options.forEach((opt) => {
+          if (category) {
+            opts.push({ name: opt, category, domain: a.domain, eligible: true });
+          }
+        });
       });
-    });
     return opts;
   }, [assessments]);
 

--- a/src/index.css
+++ b/src/index.css
@@ -53,7 +53,7 @@ body{
 }
 h1{font-size:24px}
 h2{font-size:18px}
-label,.title,.subtitle,.section-title,.card-title,h1,h2,h3,h4,h5,h6{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.title,.subtitle,.section-title,.card-title,h1,h2,h3,h4,h5,h6{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 a,button{transition:color var(--t-fast) var(--ease),background-color var(--t-fast) var(--ease),border-color var(--t-fast) var(--ease),box-shadow var(--t-fast) var(--ease),transform var(--t-fast) var(--ease)}
 /* neutral control baseline */
 button,input,select{height:44px;padding:0 var(--space-inset);font-size:16px;border-radius:var(--radius-sm);border:1px solid var(--border);background:var(--panel)}


### PR DESCRIPTION
## Summary
- avoid duplicating options in assessment selector so tabs continue filtering after adding an assessment
- remove label overflow style so client name and age inputs display correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a087f9f8c88325ac9e211941ee129f